### PR TITLE
ci: bump actions/checkout and actions/cache to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           key: ${{ github.ref }}
           path: .cache


### PR DESCRIPTION
## Summary

GitHub is deprecating Node.js 20 in actions ([blog post](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). v4 of these two actions runs on Node 20; v5 runs on Node 24.

- \`actions/checkout@v4\` -> \`actions/checkout@v5\`
- \`actions/cache@v4\` -> \`actions/cache@v5\`

\`actions/setup-python\` was already on v5.

## Test plan

- [ ] CI deploy succeeds with the new action versions