### PR TITLE
Correct product reference from LED-1 to M-1

### DIFF
--- a/docs/products/m1/faq.md
+++ b/docs/products/m1/faq.md
@@ -12,7 +12,7 @@ description: Frequently asked questions about the M-1 controller.
 
 3\. **What is the maximum power output of the M-1?**
 
-* The LED-1 is able to safely offer 3 Amps of power using 5 Volts when using the usb-c cable and stock power supply.
+* The M-1 is able to safely offer 3 Amps of power using 5 Volts when using the usb-c cable and stock power supply.
 
 4\. **Scrolling Text does not show as an effect, what am I doing wrong?**
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the product reference in the FAQ to properly identify the M-1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->