### PR TITLE
docs: add CONTRIBUTING.md and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+<!--
+  You are amazing! Thanks for contributing to Apollo Docs!
+  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
+  
+  IMPORTANT: This PR must target the `dev` branch, not `main`.
+  PRs against `main` will not be merged. Switch the base branch to `dev`
+  using the dropdown above.
+-->
+
+## What does this implement/fix?
+
+
+
+## Types of changes
+<!--
+  What type of change does your PR introduce?
+  NOTE: Please, check only 1! box!
+  If your PR requires multiple boxes to be checked, you'll most likely need to
+  split it into multiple PRs. This makes things easier and faster to code review.
+-->
+
+- [ ] Typo / wording fix
+- [ ] Content update (correcting outdated info, adding missing steps, clarifications)
+- [ ] New page or new product section
+- [ ] Page move / rename (redirect added in `mkdocs.yml`)
+- [ ] Image / screenshot update
+- [ ] Nav / structure change
+- [ ] Site config or theme change
+- [ ] CI / workflows / dependencies — Does not publish
+
+## Checklist:
+<!--
+  Put an x in the boxes that apply. You can also fill these out after
+  creating the PR. If you're unsure about any of them, don't hesitate to ask.
+-->
+
+  - [ ] This PR targets the `dev` branch (not `main`)
+  - [ ] Changes previewed locally with `mkdocs serve`
+  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
+  - [ ] If new pages were added, nav was updated in `mkdocs.yml`
+
+<!--
+  Thank you for contributing <3
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to Apollo Docs
+
+Thank you for contributing to Apollo Docs! 🎉 We welcome all contributions.
+
+## How to Contribute
+
+### 🐛 Reporting Doc Bugs
+- Check existing issues first
+- Include: page URL, what's wrong (typo, broken link, outdated info, missing step), and what you expected to see
+
+### 💡 Doc Improvements
+- Check existing issues first
+- Describe the gap and what would help (new page, clearer wording, screenshots, missing product, etc.)
+- Be open to discussion
+
+### 🔧 Doc Contributions
+1. Fork the repository and create a branch from `dev` (not `main`)
+2. Make changes following our standards
+3. Preview locally with `mkdocs serve`
+4. Submit a Pull Request **targeting `dev`** (PRs to `main` will not be merged)
+
+## Quick Setup
+```bash
+# Clone your fork
+git clone https://github.com/YOUR_USERNAME/docs.git
+cd docs
+
+# Create branch FROM dev
+git fetch origin dev
+git checkout -b docs/your-change origin/dev
+
+# Install MkDocs and required plugins
+pip install -r requirements.txt
+
+# Live preview at http://127.0.0.1:8000
+mkdocs serve
+```
+
+## Pull Request Process
+1. **Target the `dev` branch** when opening your PR. The `main` branch is updated by maintainers from `dev`.
+2. If you moved or renamed a page, add a redirect in the `redirects` plugin section of `mkdocs.yml` so external links keep working.
+3. If you added a new page, add it to the nav in `mkdocs.yml`.
+4. Verify the build is clean (no broken links or missing-plugin errors) via `mkdocs build`.
+5. Fill out the PR template and link any related issues.
+6. Use PR title format: `<type>: <description>` (types: `docs`, `fix`, `feat`, `chore`)
+
+## Doc Standards
+- MkDocs Material: see https://squidfunk.github.io/mkdocs-material/ for admonitions, tabs, and content tabs syntax
+- Snippets: when including parts of a file with `--8<-- "file.md:N:"`, start at line 5 to skip YAML front matter
+- Images: place in `docs/assets/`, keep under 750px wide where possible (CI auto-resizes, but smaller source files render faster)
+- Internal links: use site-relative paths so they work in the published site
+
+## Contact & Support
+- **Issues**: GitHub Issues for bugs and improvement requests
+- **Email**: support@apolloautomation.com
+- **Live site**: https://wiki.apolloautomation.com
+
+Thank you for making Apollo Docs better! 💙


### PR DESCRIPTION
## Summary
- Adds `CONTRIBUTING.md` at repo root with the new contribution flow (branch from `dev`, PR to `dev`, local preview via `mkdocs serve`).
- Adds `.github/PULL_REQUEST_TEMPLATE.md` mirroring the structure used in our product repos (AIR-1, PUMP-1, etc.) but with doc-specific change types and checklist items.
- Both files prominently note that PRs must target `dev`, not `main`.

## Why
- Contributors had no on-repo guidance for how to set up the docs locally or which branch to target. This caused PRs to land on `main` and break the CloudCannon sync.
- Aligns visual style and "DO NOT DELETE TEXT" convention with the rest of the Apollo org repos.

## Notable differences from product-repo templates
- No `Version:` field (docs don't version like ESPHome firmware).
- "Branch from" target is `dev`, not `main`.
- Change types replaced with doc-relevant categories (typo, content update, new page, page move + redirect, image, nav, config, CI).
- Checklist focuses on `mkdocs serve` preview, redirect addition for moved pages, and nav updates for new pages.

## Test plan
- [ ] CONTRIBUTING.md renders correctly on the GitHub repo page
- [ ] PR template auto-populates the body when opening a new PR against this repo
- [ ] No mkdocs build regressions (these files are at repo root / `.github/` and not part of the docs nav)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GitHub pull request template with structured sections and checklists for contributor submissions
  * Introduced comprehensive contributing guide with documentation standards, local build instructions, and contribution workflow requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->