### PR TITLE
chore: replace deprecated uslugify with configurable slugify

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,7 +138,9 @@ markdown_extensions:
       alternate_style: true
 #brandon added this 4/27/25 - allows for content tabs like iphone vs android
       # use a slugifier so IDs come from your tab titles
-      slugify: !!python/name:pymdownx.slugs.uslugify
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
       # word separator (defaults to "-")
       separator: "-"
       # whether to prefix with the parent header’s slug (optional)


### PR DESCRIPTION
## Summary
Replaces the deprecated `pymdownx.slugs.uslugify` reference in `mkdocs.yml` with the configurable `pymdownx.slugs.slugify` (`case: lower`). Eliminates the `DeprecationWarning: 'uslugify' is deprecated` warning seen in CloudCannon and CI build logs.

## Why
`pymdownx.slugs.uslugify` was deprecated in pymdown-extensions in favor of the configurable `slugify` factory. The two are functionally identical when `case: lower` is set, so existing tab anchor URLs do not change.

## Behavior change
None. `uslugify` was just `slugify(case='lower')` under the hood, so generated slugs and anchors are identical. Existing internal/external links to tab anchors continue to resolve.

## Test plan
- [ ] Build runs without the `'uslugify' is deprecated` warning
- [ ] A page with content tabs (e.g., the Setup pages with iPhone/Android tabs) still renders tabs correctly
- [ ] Tab anchor URLs unchanged (no broken bookmarks)