### PR TITLE
chore(cloudcannon): exclude /assets and /stylesheets from collection scan

### DIFF
--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -23,6 +23,8 @@ collections_config:
       exclude:
         - /schema
         - /schema.json
+        - /assets
+        - /stylesheets
     name: Documentation
     icon: notes
     disable_add: false


### PR DESCRIPTION
## Summary
Adds `/assets` and `/stylesheets` to the docs collection's exclude filter in `cloudcannon.config.yml`. Eliminates hundreds of `skipped due to unknown parser` log lines from the CloudCannon reader for image and CSS files.

## Why
CloudCannon's reader recursively walks every file under the configured collection path (`docs/`) and tries to parse each one. Anything that isn't markdown/YAML/JSON/etc. gets logged as "skipped due to unknown parser". With ~hundreds of images in `docs/assets/` and several stylesheets, the reader log was almost entirely this noise. Excluding the directories tells the reader to skip them entirely (faster scan, clean log).

## Behavior change
- ✅ Markdown editing in CloudCannon GUI: unchanged
- ✅ Image picker in markdown editor: unchanged (uses `_inputs.image.allowed_sources: site-files` which is independent of collection scope)
- ✅ Image uploads: unchanged (still routed to `docs/assets/` via `paths.uploads`)
- ✅ Built site rendering: unchanged (mkdocs sees all files regardless of CC collection config)
- 🔵 The "Documentation" collection sidebar will now show only content pages, not images and CSS files mixed in. Cleaner navigation.

## Test plan
- [ ] CloudCannon reader log no longer prints `skipped due to unknown parser` for files under `/assets` or `/stylesheets`
- [ ] Build still succeeds
- [ ] Spot-check editing a markdown page in CloudCannon GUI: image insertion still works