### PR TITLE
fix(css): make content images responsive on mobile

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -26,14 +26,17 @@ ul ul li {
     font-size: 0.95em !important; /* Optional: adjust font size for nested items */
 }
 
-/* brandon edited this while trying to fix images */
+/* Responsive images: never overflow the viewport, preserve aspect ratio,
+   keep a reasonable visual cap on wide screens. */
 article.md-typeset img {
-  max-width: 500px
+  max-width: 100%;
+  height: auto;
 }
 
-/* brandon edited this while trying to fix images */
-article.md-typeset img {
-  max-height: 600px
+@media screen and (min-width: 60em) {
+  article.md-typeset img {
+    max-width: 500px;
+  }
 }
 
 /* Custom song admonitions - rainbow colors with music note icon */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,6 @@ extra_css:
   - https://unicons.iconscout.com/release/v4.0.8/css/line.css
   - https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css
   # - css/lightgallery.min.css
-  - stylesheets/extra.css
   - stylesheets/nocopy.css
   - stylesheets/design.css
   - stylesheets/osano.css


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

Fixes broken layout on mobile across the entire wiki. Pages were rendering with horizontal scroll and chrome misalignment because images embedded with `![](...)` overflowed the content column.

**Root cause** in `docs/stylesheets/extra.css`:

```css
article.md-typeset img {
  max-width: 500px
}
article.md-typeset img {
  max-height: 600px
}
```

`max-width: 500px` is a fixed pixel value with no responsive fallback. On phone viewports (typically 360-414px wide), a 500px-cap image still exceeds the available column, pushes the body out of bounds, and breaks responsive behavior site-wide.

**The fix** is the canonical responsive image pattern: `max-width: 100%; height: auto;` so images scale to fit any viewport while preserving aspect ratio. The previous 500px desktop cap is preserved behind a `@media screen and (min-width: 60em)` query so desktop visuals are unchanged. The 60em breakpoint matches the existing banner-padding breakpoint in `design.css:549`, so we are not introducing a new ad-hoc breakpoint.

The standalone `max-height: 600px` rule is dropped. With `height: auto` it was redundant for normal screenshots and could cause unexpected cropping on tall mobile images.

Also removes a duplicate `stylesheets/extra.css` entry in `extra_css` in `mkdocs.yml` while we are in the area.

### Out of scope follow-ups
- YouTube `<iframe>` embeds hard-coded to `width="560" height="315"` will still overflow on mobile. Worth a separate small PR with a `.cms-embed iframe { max-width: 100%; }` wrapper.
- Asset weight: many screenshots are multi-megabyte JPEGs. Optimization is a separate effort.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [ ] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [x] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [ ] Changes previewed locally with `mkdocs serve`
  - [x] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [x] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->