### PR TITLE
fix(css): make YouTube iframe embeds responsive on mobile

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -39,6 +39,21 @@ article.md-typeset img {
   }
 }
 
+/* Responsive video embeds: scale to viewport, hold 16:9, cap at the
+   intrinsic 560px on wide screens. Authors keep using the existing
+   <div class="cms-embed"><iframe ...></iframe></div> markup. */
+article.md-typeset .cms-embed {
+  width: 100%;
+  max-width: 560px;
+  aspect-ratio: 16 / 9;
+}
+
+article.md-typeset .cms-embed iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
 /* Custom song admonitions - rainbow colors with music note icon */
 :root {
   --md-admonition-icon--song-red: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/></svg>');


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

Follow-up to #745 (responsive images). YouTube video embeds across the wiki are hard-coded to `width="560" height="315"`, so on phone viewports (typically 360-414px) the iframe overflows the content column and reintroduces horizontal scroll on every page with a video, including most product Introductions, teardown articles, and reviews.

The fix is one CSS block in `extra.css` targeting the existing `.cms-embed` wrapper:

```css
article.md-typeset .cms-embed {
  width: 100%;
  max-width: 560px;
  aspect-ratio: 16 / 9;
}

article.md-typeset .cms-embed iframe {
  width: 100%;
  height: 100%;
  border: 0;
}
```

- `max-width: 560px` preserves the current desktop look (intrinsic embed size).
- `aspect-ratio: 16 / 9` keeps the YouTube-native shape at every width without the legacy `padding-bottom: 56.25%` hack.
- `width/height: 100%` on the iframe lets the wrapper drive sizing, so the hard-coded `width="560" height="315"` HTML attributes become harmless hints.
- No markdown changes, authors keep using the existing `<div class="cms-embed"><iframe ...></iframe></div>` wrapper.

A pre-flight grep confirmed `.cms-embed` is the only wrapper class used for video embeds across the wiki. The single bare `<iframe>` outlier (`docs/homey/products/mtr1/setup/zones-hlk.md`) is an internal HTML snippet already at `width="100%"` and is unaffected.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [ ] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [x] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [ ] Changes previewed locally with `mkdocs serve`
  - [x] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [x] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->