### PR TITLE
docs(m1): flatten nav back to standard layout, keep ESPHome subsection

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -442,27 +442,27 @@ nav:
       - M-1 (LED Matrix):
           - Introduction: products/m1/introduction.md
           - FAQ: products/m1/faq.md
-          - Hardware:
-            - Multiple Panels: products/m1/setup/m1-multiple-panels.md
-          - WLED-MM:
-            - Getting Started: products/m1/setup/getting-started-m1.md
+          - Getting Started: products/m1/setup/getting-started-m1.md
+          - Multiple Panels: products/m1/setup/m1-multiple-panels.md
+          - Additional Info:
             - General Tips: products/m1/setup/m1-general-tips.md
             - Matrix Settings: products/m1/setup/m1-matrix-settings.md
             - Segments: products/m1/setup/m1-segments.md
             - Pinout Guide: products/m1/setup/m1-pinout-guide.md
-            - Microphone Addon: products/m1/addons/adding-microphone-to-m-1.md
-            - Examples:
-              #need to revisit pixelmagictool at some point
-#              - Create Logo Image: products/m1/examples/create-logo-image.md
-              - Add GIFs to WLED: products/m1/examples/add-gifs-to-wled.md
-              - Scrolling Text: products/m1/examples/scrolling-text.md
-              - QR Code Generator: products/m1/examples/qr-code-generator.md
-              - Share Data From Home Assistant : products/m1/examples/share-data-from-home-assistant.md
-            - Troubleshooting:
-              - M-1 Boot Mode: products/m1/troubleshooting/m1-boot-mode.md
-              - Factory Re-Flash M-1: products/m1/troubleshooting/m1-reflash.md
-              - Find IP and Hostname: products/m1/troubleshooting/m1-find-ip-address-and-hostname.md
-          - ESPHome:
+          - Addons:
+            - Microphone: products/m1/addons/adding-microphone-to-m-1.md
+          - Examples:
+            #need to revisit pixelmagictool at some point
+#            - Create Logo Image: products/m1/examples/create-logo-image.md
+            - Add GIFs to WLED: products/m1/examples/add-gifs-to-wled.md
+            - Scrolling Text: products/m1/examples/scrolling-text.md
+            - QR Code Generator: products/m1/examples/qr-code-generator.md
+            - Share Data From Home Assistant : products/m1/examples/share-data-from-home-assistant.md
+          - Troubleshooting:
+            - M-1 Boot Mode: products/m1/troubleshooting/m1-boot-mode.md
+            - Factory Re-Flash M-1: products/m1/troubleshooting/m1-reflash.md
+            - Find IP and Hostname: products/m1/troubleshooting/m1-find-ip-address-and-hostname.md
+          - ESPHome Firmware:
             - Getting Started: products/m1/setup/getting-started-m1-esphome.md
             - Reflash: products/m1/troubleshooting/m1-reflash-esphome.md
             - Examples:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

The Hardware / WLED-MM / ESPHome sibling subsections introduced in #747 buried Getting Started behind a click on "WLED-MM" and stopped matching the sidebar layout used by every other product in the wiki.

This PR flattens the M-1 nav back to the standard product skeleton (Introduction, FAQ, Getting Started, Multiple Panels, Additional Info, Addons, Examples, Troubleshooting, Reviews) since M-1 units ship with WLED-MM pre-flashed, and consolidates all ESPHome content under a single "ESPHome Firmware" subsection at the bottom for users who opt into the alternative firmware.

```
M-1 (LED Matrix)
├── Introduction
├── FAQ
├── Getting Started        (WLED, top-level)
├── Multiple Panels
├── Additional Info
├── Addons
├── Examples
├── Troubleshooting
├── ESPHome Firmware       (new subsection, all alt-firmware content here)
│   ├── Getting Started
│   ├── Reflash
│   └── Examples
│       └── SendSpin
└── Reviews
```

No file moves, no new pages, no markdown changes. The cross-firmware tip admonitions on both Getting Started pages remain in place so anyone who lands on the wrong one still has a one-click pivot.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [ ] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [x] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [ ] Changes previewed locally with `mkdocs serve`
  - [x] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [x] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized M-1 (LED Matrix) documentation navigation for improved structure and accessibility. Flattened the hierarchy to present content under clearer sections: Getting Started, Multiple Panels, and Additional Info. Moved microphone addon documentation to a dedicated Addons section. Updated ESPHome section header for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->