### PR TITLE
Fix mkdocs build warnings (ESK-1 nav path, M-1 cross-links)

### DIFF
--- a/docs/products/m1/setup/getting-started-m1-esphome.md
+++ b/docs/products/m1/setup/getting-started-m1-esphome.md
@@ -6,7 +6,7 @@ description: Getting started with your new M-1 running the hub75-studio ESPHome 
 
 !!! tip "Running WLED-MM instead?"
 
-    If you're using the stock WLED-MoonModules firmware that ships pre-flashed, head to the [WLED-MM Getting Started page](../getting-started-m1/) instead.
+    If you're using the stock WLED-MoonModules firmware that ships pre-flashed, head to the [WLED-MM Getting Started page](getting-started-m1.md) instead.
 
 This guide walks you through replacing the stock WLED-MM firmware with [hub75-studio](https://github.com/pavlov-net/hub75-studio), an ESPHome firmware tailored for the M-1, and getting it onto your home network and into Home Assistant.
 

--- a/docs/products/m1/setup/getting-started-m1.md
+++ b/docs/products/m1/setup/getting-started-m1.md
@@ -6,7 +6,7 @@ description: Getting started with your new M-1 running the stock WLED-MM firmwar
 
 !!! tip "Running ESPHome instead?"
 
-    If you flashed the [hub75-studio](https://github.com/pavlov-net/hub75-studio) ESPHome firmware, head to the [ESPHome Getting Started page](../getting-started-m1-esphome/) instead.
+    If you flashed the [hub75-studio](https://github.com/pavlov-net/hub75-studio) ESPHome firmware, head to the [ESPHome Getting Started page](getting-started-m1-esphome.md) instead.
 
 Congrats on your new M-1! Below we will go through steps to get you up and running in no time on the stock WLED-MM firmware.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -501,7 +501,7 @@ nav:
             - Teardown and Reassembly Of BTN-1: products/btn1/troubleshooting/btn1-teardown.md
             - Reset Wi-Fi Credentials: products/btn1/troubleshooting/btn1-reset-wi-fi-credentials.md
       - ESPHome Starter Kit:
-          - Button Getting Started: products/esk1/buttongettingstarted.md
+          - Button Getting Started: products/ESPHome-Starter-Kit/buttongettingstarted.md
       - Holiday Ornaments:
           - H-1:
               - Introduction: products/h1/introduction.md


### PR DESCRIPTION
## Summary
Clears three mkdocs build warnings:
- ESPHome Starter Kit nav now points at `products/ESPHome-Starter-Kit/buttongettingstarted.md` (the renamed dir) instead of the old `products/esk1/...` path.
- M-1 Getting Started cross-links now use `.md`-relative paths (`getting-started-m1.md` / `getting-started-m1-esphome.md`) instead of `../`-based URLs that mkdocs couldn't validate. Both files live in the same dir.

## Test plan
- [ ] `mkdocs serve` locally, confirm no WARNING/INFO messages for the three paths above.
- [ ] WLED-MM Getting Started page → "Running ESPHome instead?" link still routes to the ESPHome page.
- [ ] ESPHome Getting Started page → "Running WLED-MM instead?" link still routes to the WLED-MM page.
- [ ] Sidebar nav still shows ESPHome Starter Kit → Button Getting Started, link works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Fixed hyperlink references in M1 setup guides for improved navigation between related documentation pages.
  * Updated navigation configuration for the ESPHome Starter Kit section to ensure correct page routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->