### PR TITLE
docs(m1): add my.home-assistant.io badge for ESPHome Device Builder install

### DIFF
--- a/docs/products/m1/setup/getting-started-m1-esphome.md
+++ b/docs/products/m1/setup/getting-started-m1-esphome.md
@@ -66,7 +66,9 @@ Head to the <a href="http://homeassistant.local:8123/config/integrations" target
 
     Adopting the M-1 into the <a href="https://esphome.io/guides/getting_started_hassio.html" target="_blank" rel="noreferrer nofollow noopener">ESPHome Device Builder</a> add-on lets you edit its YAML configuration. This is needed if you want to enable optional pages (Team Tracker, QR Codes, MSR-2 Radar, additional Now Playing instances), drive multiple chained panels, or change which pages the WizMote scene buttons map to. See the <a href="https://github.com/pavlov-net/hub75-studio/wiki/Customization" target="_blank" rel="noreferrer nofollow noopener">hub75-studio Customization wiki</a> for the full list. **Skip this section if the default firmware already does everything you need.**
 
-1\. Install the ESPHome Device Builder inside Home Assistant OS by clicking the button below. Make sure to toggle on start on Boot, Watchdog, and Show in sidebar.
+1\. Install the ESPHome Device Builder inside Home Assistant OS by clicking the button below. Make sure to toggle on Start on Boot, Watchdog, and Show in sidebar.
+
+[![Open your Home Assistant instance and show the add-on store with a specific add-on pre-selected.](https://my.home-assistant.io/badges/supervisor_addon.svg)](https://my.home-assistant.io/redirect/supervisor_addon/?addon=5c53de3b_esphome&repository_url=https%3A%2F%2Fgithub.com%2Fesphome%2Fhome-assistant-addon)
 
 2\. Navigate to the ESPHome Device Builder addon by clicking the Open Web UI button on the far right.
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

The M-1 ESPHome getting started guide tells the user to "click the button below" to install the ESPHome Device Builder add-on, but no button was actually rendered. This adds the official `my.home-assistant.io` supervisor_addon badge that deep-links straight into the user's Home Assistant supervisor add-on store with the ESPHome Device Builder pre-selected, matching the pattern already used on `products/general/setup/switch-to-beta-branch.md` and `products/general/calibrating-and-updating/updating-firmware.md`.

Also capitalized "Start on Boot" to match the actual toggle label in the Home Assistant add-on UI.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [x] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [ ] Changes previewed locally with `mkdocs serve`
  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [ ] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ESPHome setup guide with clearer installation instructions, including a convenient badge link that directly opens the Home Assistant supervisor add-on store with ESPHome pre-selected for faster setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->