### PR TITLE
docs: rename Home Assistant add-on references to app

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/buttongettingstarted.md
+++ b/docs/products/ESPHome-Starter-Kit/buttongettingstarted.md
@@ -10,7 +10,7 @@
 
 # Setting Up ESPHome Device Builder
 1. Connect to HA ( link to HA getting started )
-2. Install addon here
+2. Install app here
 3. Install driver?
 4. View it here
 5. Creating secrets file for wifi

--- a/docs/products/apolloodroid/faq.md
+++ b/docs/products/apolloodroid/faq.md
@@ -39,7 +39,7 @@ The Apollo Odroid comes equipped with:
 
 7\. **Can I customize the Home Assistant installation on the Apollo Odroid?**
 
-* Absolutely! The Apollo Odroid runs Home Assistant OS, which is fully customizable. You can add integrations, automations, and even custom add-ons to tailor the system to your smart home needs.
+* Absolutely! The Apollo Odroid runs Home Assistant OS, which is fully customizable. You can add integrations, automations, and even custom apps to tailor the system to your smart home needs.
 
 8\. **Do I need any special software to configure the Apollo Odroid?**
 

--- a/docs/products/btn1/setup/getting-started.md
+++ b/docs/products/btn1/setup/getting-started.md
@@ -80,7 +80,7 @@ To connect through the sensor's onboard hotspot follow the below:
 
     Feel free to [skip to the next section by clicking here](https://wiki.apolloautomation.com/products/general/setup/getting-started/#connecting-to-home-assistant-via-esphome-integration "Click to jump to the ESPHome Integration steps!") unless you need to rename your sensor or do manual edits to the yaml
 
-You can add the ESPHome Device Builder addon in Home Assistant to easily update your device or edit the yaml. If you don't have ESPHome Device Builder addon installed you can <a href="http://homeassistant.local:8123/hassio/store" target="_blank" rel="noreferrer nofollow noopener">search esphome device builder on the addon store</a> and install it.
+You can add the ESPHome Device Builder app in Home Assistant to easily update your device or edit the yaml. If you don't have the ESPHome Device Builder app installed you can <a href="http://homeassistant.local:8123/hassio/store" target="_blank" rel="noreferrer nofollow noopener">search esphome device builder in the app store</a> and install it.
 
 Make sure to fill out your Wi-Fi details in the **secrets** section by clicking on the **secrets** button.
 

--- a/docs/products/general/faq.md
+++ b/docs/products/general/faq.md
@@ -49,7 +49,7 @@ description: Frequently Asked Questions.
 #### **7\. I am getting the error "Failed to import device" in ESPHome Dashboard when trying to adopt my Apollo device.**
 
 * Make sure you have enough free space in Home Assistant - Protip: check for old backups you can delete!
-* If your space is not an issue then please reboot or even try reinstalling the ESPHome Device Builder addon and see if that helps!
+* If your space is not an issue then please reboot or even try reinstalling the ESPHome Device Builder app and see if that helps!
 
 ---
 

--- a/docs/products/general/setup/getting-started.md
+++ b/docs/products/general/setup/getting-started.md
@@ -68,7 +68,7 @@ If this does not automatically open the dashboard, please open your web browser 
 
     Feel free to [skip to the next section by clicking here](https://wiki.apolloautomation.com/products/general/setup/getting-started/#connecting-to-home-assistant-via-esphome-integration "Click to jump to the ESPHome Integration steps!")unless you need to rename your sensor or do manual edits to the yaml
 
-You can add the ESPHome Device Builder addon in Home Assistant to easily update your device or edit the yaml. If you don't have ESPHome Device Builder addon installed you can [follow the steps here](https://esphome.io/guides/getting_started_hassio.html#installing-esphome-device-compiler "Getting Started guide for installing ESPHome Device Builder").
+You can add the ESPHome Device Builder app in Home Assistant to easily update your device or edit the yaml. If you don't have the ESPHome Device Builder app installed you can [follow the steps here](https://esphome.io/guides/getting_started_hassio.html#installing-esphome-device-compiler "Getting Started guide for installing ESPHome Device Builder").
 
 Make sure to fill out your Wi-Fi details in the SECRETS section by clicking on the SECRETS Image below.
 

--- a/docs/products/general/troubleshooting/connection-issues.md
+++ b/docs/products/general/troubleshooting/connection-issues.md
@@ -24,7 +24,7 @@ wifi:
   power_save_mode: none
 ```
 
-1\. Select the ESPHome add on and then select Edit under your desired device.
+1\. Select the ESPHome app and then select Edit under your desired device.
 
 ![](/assets/screenshot-2024-10-25-at-5-14-48-pm.png)
 

--- a/docs/products/general/troubleshooting/removing-device-from-home-assistant.md
+++ b/docs/products/general/troubleshooting/removing-device-from-home-assistant.md
@@ -4,15 +4,15 @@ description: Tutorial to Removing Device From Home Assistant.
 ---
 # Removing Device From Home Assistant
 
-##### ESPHome addon
+##### ESPHome app
 
 This will cover how to remove an Apollo device from Home Assistant
 
-!!! tip "Skip this step unless you took control of your device with the ESPHome Device Builder addon!"
+!!! tip "Skip this step unless you took control of your device with the ESPHome Device Builder app!"
 
     This step is only necessary for advanced users who added the device to the ESPHome device builder to edit the yaml and customize the device. Please skip to the next step if you are only using the ESPHome or Apollo Automation integration!
 
-1\. Navigate to Home Assistant and <a href="http://homeassistant.local:8123/5c53de3b_esphome/ingress" target="_blank" rel="noreferrer nofollow noopener">open your ESPHome Device Builder</a> addon.
+1\. Navigate to Home Assistant and <a href="http://homeassistant.local:8123/5c53de3b_esphome/ingress" target="_blank" rel="noreferrer nofollow noopener">open your ESPHome Device Builder</a> app.
 
 ![image.png](/assets/esphome-device-builder-addon-image.png)
 

--- a/docs/products/h1/code.md
+++ b/docs/products/h1/code.md
@@ -25,7 +25,7 @@ If no device shows, click cancel and then install the recommended driver that sh
 6\. VERY IMPORTANT - you need to unplug your device and plug it back in to leave boot mode!
 
 1. After finishing, check for the Apollo hotspot and connect. This might not show if you previously had the MTR-1 connected to your wifi
-2. Log into Home Assistant and go to the ESPHome addon check to see if you can adopt the device.
+2. Log into Home Assistant and go to the ESPHome app check to see if you can adopt the device.
 
 If you encounter the below error, please complete the [Putting H-1 In Boot Mode Document](https://wiki.apolloautomation.com/products/h1/boot-mode/) and go back to step 3.
 

--- a/docs/products/m1/examples/media-proxy.md
+++ b/docs/products/m1/examples/media-proxy.md
@@ -4,11 +4,11 @@ description: Stream GIFs, YouTube videos, still images, and album art to your M-
 ---
 # Media Proxy
 
-The <a href="https://github.com/pavlov-net/media-proxy" target="_blank" rel="noreferrer nofollow noopener">Media Proxy</a> is a Home Assistant add-on that takes almost any media URL, resizes and decodes it for your panel, and streams the result to the M-1 over the network. It's how the M-1 ESPHome firmware plays animated GIFs, YouTube videos, still images, and album art on a 64x64 panel without you having to convert anything by hand.
+The <a href="https://github.com/pavlov-net/media-proxy" target="_blank" rel="noreferrer nofollow noopener">Media Proxy</a> is a Home Assistant app that takes almost any media URL, resizes and decodes it for your panel, and streams the result to the M-1 over the network. It's how the M-1 ESPHome firmware plays animated GIFs, YouTube videos, still images, and album art on a 64x64 panel without you having to convert anything by hand.
 
 !!! tip "Need to install it first?"
 
-    Head to the **Media Proxy** section of the <a href="https://wiki.apolloautomation.com/products/m1/setup/getting-started-m1-esphome/#media-proxy" target="_blank" rel="noreferrer nofollow noopener">M-1 ESPHome Getting Started</a> page to install the add-on, then come back here.
+    Head to the **Media Proxy** section of the <a href="https://wiki.apolloautomation.com/products/m1/setup/getting-started-m1-esphome/#media-proxy" target="_blank" rel="noreferrer nofollow noopener">M-1 ESPHome Getting Started</a> page to install the app, then come back here.
 
 ## What you can do
 
@@ -54,5 +54,5 @@ Once Media Proxy is installed and running, all of these things are driven from a
 ## Going further
 
 - The <a href="https://github.com/pavlov-net/media-proxy/blob/main/README.md" target="_blank" rel="noreferrer nofollow noopener">Media Proxy README</a> covers fit modes, autocrop tuning, hardware acceleration setup, and the YAML config file if you want to tweak how content gets resized or decoded.
-- The <a href="https://github.com/stuartparmenter/homeassistant-addons" target="_blank" rel="noreferrer nofollow noopener">homeassistant-addons repo</a> is the home of the Media Proxy add-on itself, including release notes and install troubleshooting.
+- The <a href="https://github.com/stuartparmenter/homeassistant-addons" target="_blank" rel="noreferrer nofollow noopener">homeassistant-addons repo</a> is the home of the Media Proxy app itself, including release notes and install troubleshooting.
 - If you need to (re)install Media Proxy, the steps live on the <a href="https://wiki.apolloautomation.com/products/m1/setup/getting-started-m1-esphome/#media-proxy" target="_blank" rel="noreferrer nofollow noopener">M-1 ESPHome Getting Started</a> page.

--- a/docs/products/m1/examples/sendspin.md
+++ b/docs/products/m1/examples/sendspin.md
@@ -12,7 +12,7 @@ description: Use the M-1 with SendSpin audio visualizers
 
 1\. You will need to be running <a href="https://www.music-assistant.io/" target="_blank" rel="noreferrer nofollow noopener">Music Assistant</a> which has Sendspin baked in! Click the button below to install it on your Home Assistant OS setup.
 
-[![Open your Home Assistant instance and show the dashboard of a Supervisor add-on.](https://my.home-assistant.io/badges/supervisor_addon.svg)](https://my.home-assistant.io/redirect/supervisor_addon/?addon=d5369777_music_assistant&amp;repository_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fhome-assistant-addon)
+[![Open your Home Assistant instance and show the dashboard of an app.](https://my.home-assistant.io/badges/supervisor_addon.svg)](https://my.home-assistant.io/redirect/supervisor_addon/?addon=d5369777_music_assistant&amp;repository_url=https%3A%2F%2Fgithub.com%2Fmusic-assistant%2Fhome-assistant-addon)
 
 !!! success "This tutorial expects you to already have music providers and players setup."
 

--- a/docs/products/m1/examples/share-data-from-home-assistant.md
+++ b/docs/products/m1/examples/share-data-from-home-assistant.md
@@ -14,7 +14,7 @@ description: >-
 
 The <a href="https://www.home-assistant.io/integrations/wled/" target="_blank" rel="noreferrer nofollow noopener">WLED integration for Home Assistant</a> does not support sending data from our devices directly to the M-1 LED Matrix, however, we are still able to do so using the <a href="https://mm.kno.wled.ge/interfaces/json-api/" target="_blank" rel="noreferrer nofollow noopener">WLED JSON API</a>. This is an advanced tutorial but if you follow each step closely you should be able to follow along!
 
-1\. Install "Studio Code Server" <a href="https://github.com/hassio-addons/addon-vscode" target="_blank" rel="noreferrer nofollow noopener">from the addon store</a> in Home Assistant OS. Click Open Webui and navigate to your configuration.yaml file.
+1\. Install "Studio Code Server" <a href="https://github.com/hassio-addons/addon-vscode" target="_blank" rel="noreferrer nofollow noopener">from the app store</a> in Home Assistant OS. Click Open Webui and navigate to your configuration.yaml file.
 
 ![](/assets/m1-navigate-to-configuration-yaml.gif)
 

--- a/docs/products/m1/setup/getting-started-m1-esphome.md
+++ b/docs/products/m1/setup/getting-started-m1-esphome.md
@@ -64,13 +64,13 @@ Head to the <a href="http://homeassistant.local:8123/config/integrations" target
 
 !!! tip "Required for advanced customization"
 
-    Adopting the M-1 into the <a href="https://esphome.io/guides/getting_started_hassio.html" target="_blank" rel="noreferrer nofollow noopener">ESPHome Device Builder</a> add-on lets you edit its YAML configuration. This is needed if you want to enable optional pages (Team Tracker, QR Codes, MSR-2 Radar, additional Now Playing instances), drive multiple chained panels, or change which pages the WizMote scene buttons map to. See the <a href="https://github.com/pavlov-net/hub75-studio/wiki/Customization" target="_blank" rel="noreferrer nofollow noopener">hub75-studio Customization wiki</a> for the full list. **Skip this section if the default firmware already does everything you need.**
+    Adopting the M-1 into the <a href="https://esphome.io/guides/getting_started_hassio.html" target="_blank" rel="noreferrer nofollow noopener">ESPHome Device Builder</a> app lets you edit its YAML configuration. This is needed if you want to enable optional pages (Team Tracker, QR Codes, MSR-2 Radar, additional Now Playing instances), drive multiple chained panels, or change which pages the WizMote scene buttons map to. See the <a href="https://github.com/pavlov-net/hub75-studio/wiki/Customization" target="_blank" rel="noreferrer nofollow noopener">hub75-studio Customization wiki</a> for the full list. **Skip this section if the default firmware already does everything you need.**
 
 1\. Install the ESPHome Device Builder inside Home Assistant OS by clicking the button below. Make sure to toggle on Start on Boot, Watchdog, and Show in sidebar.
 
 [![Open your Home Assistant instance and show the add-on store with a specific add-on pre-selected.](https://my.home-assistant.io/badges/supervisor_addon.svg)](https://my.home-assistant.io/redirect/supervisor_addon/?addon=5c53de3b_esphome&repository_url=https%3A%2F%2Fgithub.com%2Fesphome%2Fhome-assistant-addon)
 
-2\. Navigate to the ESPHome Device Builder addon by clicking the Open Web UI button on the far right.
+2\. Navigate to the ESPHome Device Builder app by clicking the Open Web UI button on the far right.
 
 ![](../../../assets/m-1-esphome-device-builder-open.gif)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

Home Assistant has rebranded supervisor "add-ons" to "apps" in the UI. This updates the user-facing docs to match. Scope is **only** prose that refers to a Home Assistant supervisor add-on (ESPHome Device Builder, Music Assistant, Studio Code Server, Media Proxy, generic HA OS "custom add-ons" wording).

Explicitly **not** changed:
- Apollo physical hardware add-ons (CO2 module, GPIO header, articulating stand, 90-degree USB-C, microphone, food probe, ceiling mount, BTN-1 mount, optional probes, etc.) - those are Apollo product names and unrelated to the HA rebrand.
- `homey/**` (Apollo Homey edition has no add-ons/apps concept).
- URL query parameters on `my.home-assistant.io` badge links (`?addon=...&repository_url=...home-assistant-addon`) - HA still accepts these as the literal redirect parameters; renaming would break the deep links.
- GitHub repository names like `homeassistant-addons` and `home-assistant-addon`.
- Asset filenames (`esphome-addon-image.svg`, `supervisor-addon.svg`, `esphome-device-builder-addon-image.png`, `mtr-1-90-addon-pic-*.jpg`, etc.).
- Wiki URL paths under `/addons/` (would break inbound links and Apollo's product hardware tree).

Files touched (12, all in `docs/products/`):
- `ESPHome-Starter-Kit/buttongettingstarted.md`
- `apolloodroid/faq.md`
- `btn1/setup/getting-started.md`
- `general/faq.md`
- `general/setup/getting-started.md`
- `general/troubleshooting/connection-issues.md`
- `general/troubleshooting/removing-device-from-home-assistant.md`
- `h1/code.md`
- `m1/examples/media-proxy.md`
- `m1/examples/sendspin.md` (badge alt text only)
- `m1/examples/share-data-from-home-assistant.md`
- `m1/setup/getting-started-m1-esphome.md`

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [x] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [ ] Changes previewed locally with `mkdocs serve`
  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [ ] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->