### PR TITLE
ESK-1: fix broken admonition and video embed on first-steps page

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/first-steps.md
+++ b/docs/products/ESPHome-Starter-Kit/first-steps.md
@@ -22,7 +22,7 @@ Your kit arrives as a single snap-apart panel that contains the ESP32-C6 main bo
 
 Each module is connected to the panel by small breakaway tabs. Follow the steps below to separate them
 
-!!! ! success "Take it slow"
+!!! success "Take it slow"
 
     Bend the panel a little at a time rather than forcing it. The PCB is rigid but the components on the modules can be damaged by sharp impacts or twisting.
 
@@ -33,7 +33,7 @@ Each module is connected to the panel by small breakaway tabs. Follow the steps 
 3. If a tab leaves a small nub on the module, you can file or sand it smooth. It will not affect how the module works.
 
 <video autoplay loop muted playsinline width="100%">
-  <source src="assets/ESPHome_Starter_Kit_Break_Apart_Modules.mp4" type="video/mp4">
+  <source src="../../assets/ESPHome_Starter_Kit_Break_Apart_Modules.mp4" type="video/mp4">
   Your browser does not support embedded video.
 </video>
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  IMPORTANT: This PR must target the \`dev\` branch, not \`main\`.
  PRs against \`main\` will not be merged. Switch the base branch to \`dev\`
  using the dropdown above.
-->

## What does this implement/fix?

Two rendering bugs on https://wiki.apolloautomation.com/products/ESPHome-Starter-Kit/first-steps/:

1. **Admonition not rendering.** The "Take it slow" callout was written as `!!! ! success "Take it slow"` — the stray `!` between `!!!` and the type breaks pymdownx's admonition parser, which silently falls back to rendering the block as plain text. Fixed to `!!! success "Take it slow"` so the styled green callout actually appears.
2. **Video not embedding.** The `<source src="assets/...">` path was relative to the markdown file's directory, but the file is committed at `docs/assets/ESPHome_Starter_Kit_Break_Apart_Modules.mp4` (matching the same convention the panel image above uses: `../../assets/starter-kit-graphic.png`). Updated the video `src` to `../../assets/ESPHome_Starter_Kit_Break_Apart_Modules.mp4` so the embed loads.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Typo / wording fix
- [ ] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in \`mkdocs.yml\`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the \`dev\` branch (not \`main\`)
  - [ ] Changes previewed locally with \`mkdocs serve\`
  - [x] If pages were moved or renamed, redirects were added to \`mkdocs.yml\`
  - [x] If new pages were added, nav was updated in \`mkdocs.yml\`

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed documentation formatting in the ESPHome Starter Kit guide.
  * Corrected an embedded video link in the first-steps documentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ApolloAutomation/docs/pull/771)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->