### PR TITLE
ESK-1: fix video embed path and restore button icon sizing on first-steps

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/first-steps.md
+++ b/docs/products/ESPHome-Starter-Kit/first-steps.md
@@ -33,7 +33,7 @@ Each module is connected to the panel by small breakaway tabs. Follow the steps 
 3. If a tab leaves a small nub on the module, you can file or sand it smooth. It will not affect how the module works.
 
 <video autoplay loop muted playsinline width="100%">
-  <source src="../../assets/ESPHome_Starter_Kit_Break_Apart_Modules.mp4" type="video/mp4">
+  <source src="/assets/ESPHome_Starter_Kit_Break_Apart_Modules.mp4" type="video/mp4">
   Your browser does not support embedded video.
 </video>
 
@@ -52,4 +52,7 @@ Each module connects to the ESP32-C6 board through the FPC connectors which are 
 
 Once you've identified your modules and snapped them off the panel, the next step is to connect the ESP32-C6 to your computer and walk through your first ESPHome configuration.
 
-<a href="../setup/getting-started/" class="md-button md-button--primary">   <img src="/assets/esphome-logo.svg" />   Open ESPHome Getting Started </a>
+<a href="../setup/getting-started/" class="md-button md-button--primary">
+  <img src="/assets/esphome-logo.svg" alt="">
+  Open ESPHome Getting Started
+</a>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -158,3 +158,12 @@ article.md-typeset .cms-embed iframe {
 .tabbed-content .highlight {
   width: fit-content;
 }
+
+/* Inline icon inside .md-button (e.g. ESPHome logo next to button label).
+   Lives in CSS rather than per-page `style="..."` so CloudCannon's WYSIWYG
+   does not strip the sizing when the page is round-tripped. */
+.md-button img {
+  height: 1.2em;
+  vertical-align: -0.2em;
+  margin-right: 0.4em;
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  IMPORTANT: This PR must target the \`dev\` branch, not \`main\`.
  PRs against \`main\` will not be merged. Switch the base branch to \`dev\`
  using the dropdown above.
-->

## What does this implement/fix?

Two more rendering bugs on https://wiki.apolloautomation.com/products/ESPHome-Starter-Kit/first-steps/ (followup to #771):

1. **Video still not loading.** The previous fix used `../../assets/...` for the `<source src>`, but raw HTML `src` attributes are not rewritten by mkdocs the way markdown image links are. The browser resolved the relative path from the rendered URL (`/products/ESPHome-Starter-Kit/first-steps/`) and ended up requesting `/products/assets/ESPHome_Starter_Kit_Break_Apart_Modules.mp4`, which 404'd. Switched to root-absolute `/assets/...` to match the file's actual location under `docs/assets/`. Same convention the `<img src="/assets/esphome-logo.svg">` in the button below already uses.

2. **ESPHome Getting Started button icon overflowing.** Commit `c5e380c4` (a CloudCannon edit) flattened the `<a>` to one line and stripped the inline `style="height:1.2em;vertical-align:-0.2em;margin-right:0.4em;"` from the `<img>`. With no height constraint, the SVG rendered at its intrinsic size and overflowed the button. Restored the multi-line `<a>` and `alt=""` on the `<img>`, then moved the icon sizing into `docs/stylesheets/extra.css` as a `.md-button img` rule so the styling no longer lives on per-page inline `style` attributes that CloudCannon strips on round-trip. Site-wide rule, so any future button-with-icon picks up the same sizing automatically.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [x] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in \`mkdocs.yml\`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the \`dev\` branch (not \`main\`)
  - [ ] Changes previewed locally with \`mkdocs serve\`
  - [x] If pages were moved or renamed, redirects were added to \`mkdocs.yml\`
  - [x] If new pages were added, nav was updated in \`mkdocs.yml\`

<!--
  Thank you for contributing <3
-->