### PR TITLE
Sync dev to main

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/first-steps.md
+++ b/docs/products/ESPHome-Starter-Kit/first-steps.md
@@ -33,7 +33,7 @@ Each module is connected to the panel by small breakaway tabs. Follow the steps 
 3. If a tab leaves a small nub on the module, you can file or sand it smooth. It will not affect how the module works.
 
 <video autoplay loop muted playsinline width="100%">
-  <source src="../../assets/ESPHome_Starter_Kit_Break_Apart_Modules.mp4" type="video/mp4">
+  <source src="/assets/ESPHome_Starter_Kit_Break_Apart_Modules.mp4" type="video/mp4">
   Your browser does not support embedded video.
 </video>
 
@@ -52,4 +52,7 @@ Each module connects to the ESP32-C6 board through the FPC connectors which are 
 
 Once you've identified your modules and snapped them off the panel, the next step is to connect the ESP32-C6 to your computer and walk through your first ESPHome configuration.
 
-<a href="../setup/getting-started/" class="md-button md-button--primary">   <img src="/assets/esphome-logo.svg" />   Open ESPHome Getting Started </a>
+<a href="../setup/getting-started/" class="md-button md-button--primary">
+  <img src="/assets/esphome-logo.svg" alt="">
+  Open ESPHome Getting Started
+</a>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -158,3 +158,12 @@ article.md-typeset .cms-embed iframe {
 .tabbed-content .highlight {
   width: fit-content;
 }
+
+/* Inline icon inside .md-button (e.g. ESPHome logo next to button label).
+   Lives in CSS rather than per-page `style="..."` so CloudCannon's WYSIWYG
+   does not strip the sizing when the page is round-tripped. */
+.md-button img {
+  height: 1.2em;
+  vertical-align: -0.2em;
+  margin-right: 0.4em;
+}


### PR DESCRIPTION
Routine dev to main sync (includes #773: fix video embed path and restore button icon sizing on ESPHome Starter Kit first-steps page).