### PR TITLE
ESK-1: fix .md-button img CSS specificity (button icon still oversized)

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -161,9 +161,12 @@ article.md-typeset .cms-embed iframe {
 
 /* Inline icon inside .md-button (e.g. ESPHome logo next to button label).
    Lives in CSS rather than per-page `style="..."` so CloudCannon's WYSIWYG
-   does not strip the sizing when the page is round-tripped. */
-.md-button img {
+   does not strip the sizing when the page is round-tripped.
+   Selector qualified with `article.md-typeset` so it outranks the global
+   `article.md-typeset img { max-width: 500px; height: auto; }` rule. */
+article.md-typeset .md-button img {
   height: 1.2em;
+  width: auto;
   vertical-align: -0.2em;
   margin-right: 0.4em;
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

  IMPORTANT: This PR must target the \`dev\` branch, not \`main\`.
  PRs against \`main\` will not be merged. Switch the base branch to \`dev\`
  using the dropdown above.
-->

## What does this implement/fix?

Followup to #773 — the button icon on https://wiki.apolloautomation.com/products/ESPHome-Starter-Kit/first-steps/ was still rendering at full size after #773 deployed. Specificity bug, not a deploy issue: I verified the CSS rule was in the published `stylesheets/extra.css` but the icon was still huge.

`.md-button img` has specificity (0,1,1). The site already has a global rule earlier in the same stylesheet:

```css
article.md-typeset img {
  max-width: 100%;
  height: auto;
}
@media screen and (min-width: 60em) {
  article.md-typeset img { max-width: 500px; }
}
```

Specificity (0,1,2). It beats my new rule, so `height: auto` + `max-width: 500px` win and the SVG renders at its intrinsic 500px width.

Historically the inline `style=""` on the `<img>` was the only thing keeping the icon small — inline style outranks everything. Once CloudCannon stripped that style attribute (commit `c5e380c4`), the global image rule took over and the icon ballooned.

Fix: qualified my selector to `article.md-typeset .md-button img` (specificity 0,2,2) so it actually wins. Also added `width: auto` so the height constraint isn't fighting an inherited width. No markup changes — just makes the previously-shipped rule take effect.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [ ] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in \`mkdocs.yml\`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [x] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the \`dev\` branch (not \`main\`)
  - [ ] Changes previewed locally with \`mkdocs serve\`
  - [x] If pages were moved or renamed, redirects were added to \`mkdocs.yml\`
  - [x] If new pages were added, nav was updated in \`mkdocs.yml\`

<!--
  Thank you for contributing <3
-->