### PR TITLE
ESK: add Using Secrets tutorial

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/tutorials/using-secrets.md
+++ b/docs/products/ESPHome-Starter-Kit/tutorials/using-secrets.md
@@ -1,0 +1,226 @@
+---
+title: Using secrets.yaml
+description: Store API encryption keys, OTA passwords, MQTT credentials, and more in a single secrets.yaml file so they stay out of your device configs.
+---
+# Using `secrets.yaml`
+
+In [Getting Started](../setup/getting-started.md) you saved your Wi-Fi name and password in `secrets.yaml`. That same file can hold every other sensitive value your device needs, from your Home Assistant API key to your MQTT password. This tutorial walks through what to put in there and how to reference it from your device YAML.
+
+---
+
+## What `secrets.yaml` is
+
+`secrets.yaml` is a single file in ESPHome Device Builder that stores values you don't want pasted into every device config. Two reasons to use it:
+
+* **Safety.** You can copy a device YAML to a friend, paste it in a forum, or commit it to a public repo without leaking your Wi-Fi password or API key.
+* **One place to change things.** Rotate a password once in `secrets.yaml` and every device that references it picks up the new value on the next flash.
+
+`secrets.yaml` lives inside ESPHome Device Builder, so the same secrets are available to every device you build there.
+
+---
+
+## 1. Open `secrets.yaml`
+
+In the ESPHome Device Builder dashboard, click **Secrets** in the top right.
+
+![](../../../assets/esphome-device-builder-click-secrets.gif)
+
+You'll see a YAML file with one key per line. If you followed Getting Started you should already see `wifi_ssid` and `wifi_password` here.
+
+![](../../../assets/esphome-device-builder-secrets.png)
+
+---
+
+## 2. The syntax
+
+Each entry in `secrets.yaml` is a `key: "value"` pair:
+
+```yaml
+my_secret_name: "the value goes here"
+```
+
+In your device YAML, reference it with `!secret` followed by the key name:
+
+```yaml
+some_option: !secret my_secret_name
+```
+
+When the device compiles, ESPHome substitutes the value from `secrets.yaml` in place of the `!secret` tag.
+
+!!! warning "The key has to exist"
+
+    If you reference `!secret some_name` in a device config but `some_name` isn't defined in `secrets.yaml`, the build will fail. Spelling counts.
+
+---
+
+## 3. What to put in `secrets.yaml`
+
+Each section below shows the line you add to `secrets.yaml` and the line in your device YAML that references it.
+
+### Wi-Fi credentials
+
+You set these up in [Getting Started](../setup/getting-started.md). They're the baseline every device needs.
+
+In `secrets.yaml`:
+
+```yaml
+wifi_ssid: "your-wifi-ssid-here"
+wifi_password: "your-wifi-password-here"
+```
+
+In your device YAML:
+
+```yaml
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+```
+
+### Fallback hotspot password
+
+If you want the device's fallback hotspot to require a password instead of being open, store that here too.
+
+In `secrets.yaml`:
+
+```yaml
+ap_password: "fallback-hotspot-password"
+```
+
+In your device YAML:
+
+```yaml
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "Apollo ESK-1 Hotspot"
+    password: !secret ap_password
+```
+
+### Home Assistant API encryption key
+
+ESPHome encrypts the connection between your device and Home Assistant. The key is a 32-byte base64 string. The easiest way to get one is to let ESPHome Device Builder generate it for you when you first add the `api:` block, then copy that value into `secrets.yaml`.
+
+In `secrets.yaml`:
+
+```yaml
+api_encryption_key: "your-32-byte-base64-key-here"
+```
+
+In your device YAML:
+
+```yaml
+api:
+  encryption:
+    key: !secret api_encryption_key
+```
+
+!!! tip "Reuse the same key across devices"
+
+    Using the same `api_encryption_key` for every Apollo device on your network is fine and keeps your secrets file short. Home Assistant prompts for the key the first time it discovers a device, then remembers it.
+
+### OTA password
+
+OTA (over-the-air) updates let you re-flash a device wirelessly after the first USB flash. The password protects that endpoint so a stranger on your network can't push firmware to your device.
+
+In `secrets.yaml`:
+
+```yaml
+ota_password: "a-long-random-string"
+```
+
+In your device YAML:
+
+```yaml
+ota:
+  - platform: esphome
+    password: !secret ota_password
+```
+
+### Web server username and password
+
+If you enable the optional `web_server:` component to access your device at `http://device-name.local/`, you can require a login.
+
+In `secrets.yaml`:
+
+```yaml
+web_server_username: "admin"
+web_server_password: "a-strong-password"
+```
+
+In your device YAML:
+
+```yaml
+web_server:
+  port: 80
+  auth:
+    username: !secret web_server_username
+    password: !secret web_server_password
+```
+
+### MQTT broker, username, and password
+
+If you publish to an MQTT broker instead of (or in addition to) the Home Assistant API, all three of these belong in `secrets.yaml`.
+
+In `secrets.yaml`:
+
+```yaml
+mqtt_broker: "192.168.1.50"
+mqtt_username: "esphome"
+mqtt_password: "broker-password"
+```
+
+In your device YAML:
+
+```yaml
+mqtt:
+  broker: !secret mqtt_broker
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+```
+
+---
+
+## 4. A complete `secrets.yaml` example
+
+Putting it all together, a fully loaded `secrets.yaml` looks like this:
+
+```yaml
+# Wi-Fi
+wifi_ssid: "your-wifi-ssid-here"
+wifi_password: "your-wifi-password-here"
+ap_password: "fallback-hotspot-password"
+
+# Home Assistant API
+api_encryption_key: "your-32-byte-base64-key-here"
+
+# OTA updates
+ota_password: "a-long-random-string"
+
+# Web server auth
+web_server_username: "admin"
+web_server_password: "a-strong-password"
+
+# MQTT
+mqtt_broker: "192.168.1.50"
+mqtt_username: "esphome"
+mqtt_password: "broker-password"
+```
+
+You don't have to include every entry. If a device doesn't use MQTT, leave those lines out (or leave them in for the next device, the unused ones are harmless).
+
+---
+
+## Good practice
+
+!!! info "Treat `secrets.yaml` like a password manager"
+
+    * Don't share or post the file. Share device YAMLs instead, the `!secret` references are safe.
+    * Keep a backup somewhere safe (a password manager works well). If you reinstall ESPHome Device Builder you'll need to recreate it.
+    * Rotating a credential is a one-line edit here, then re-flash anything that uses it.
+
+## Next steps
+
+* Re-flash your device in ESPHome Device Builder after editing `secrets.yaml` so the new values take effect.
+* Browse [Apollo's other product wikis](https://wiki.apolloautomation.com) for examples of these secrets in real device configs.
+* Join the [Apollo Discord](https://link.apolloautomation.com/discord) if you get stuck.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -503,6 +503,8 @@ nav:
       - ESPHome Starter Kit:
           - First Steps: products/ESPHome-Starter-Kit/first-steps.md
           - Getting Started: products/ESPHome-Starter-Kit/setup/getting-started.md
+          - Tutorials:
+              - Using Secrets: products/ESPHome-Starter-Kit/tutorials/using-secrets.md
       - Holiday Ornaments:
           - H-1:
               - Introduction: products/h1/introduction.md


### PR DESCRIPTION
## Summary

Adds a new **Tutorials** subsection under ESPHome Starter Kit, with a first page covering `secrets.yaml` beyond Wi-Fi. The Getting Started page already introduces `secrets.yaml` for Wi-Fi only; this tutorial picks up from there and covers the other values most users end up storing.

The page walks through:

- What `secrets.yaml` is and why to use it
- Opening it in ESPHome Device Builder (reuses existing `esphome-device-builder-click-secrets.gif` and `esphome-device-builder-secrets.png` assets)
- `!secret` syntax
- Sectioned entries with the `secrets.yaml` line and the device YAML line side by side for: Wi-Fi, fallback hotspot password, Home Assistant API encryption key, OTA password, `web_server:` auth, and MQTT broker/username/password
- A complete example `secrets.yaml`
- Good practice notes (don't share, keep a backup, rotate in one place)

Nav now reads:

```
ESPHome Starter Kit:
  - First Steps
  - Getting Started
  - Tutorials:
      - Using Secrets
```

URL slug: `/tutorials/using-secrets/`.

## Test plan

- [ ] Page renders in CloudCannon preview on `dev`
- [ ] Sidebar shows the new **Tutorials → Using Secrets** entry under ESPHome Starter Kit
- [ ] Both image assets resolve
- [ ] Link from this page back to Getting Started works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * New tutorial documentation on securely storing and managing Wi-Fi credentials, API keys, and other sensitive configuration data in ESPHome projects. Includes practical examples and best practices for handling secret values.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ApolloAutomation/docs/pull/782)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->