### PR TITLE
chore(toc): cap sidebar TOC depth at h2

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,6 +155,7 @@ markdown_extensions:
 #brandon added this 3/26/25
   - toc:
       permalink: true
+      toc_depth: 2
       slugify: !!python/object/apply:pymdownx.slugs.slugify
         kwds:
           case: lower


### PR DESCRIPTION
## Summary

Adds `toc_depth: 2` to the `toc` markdown extension in `mkdocs.yml`. With `toc.integrate` enabled, every h3+ heading on every page stacks into the left navigation, which gets noisy fast. Capping the integrated TOC at h2 cleans up the sidebar without changing on-page rendering.

What changes:
- **h1, h2** → sidebar entries (same as today)
- **h3, h4, h5, h6** → no sidebar entry, but still render normally on the page, still get anchor IDs, deep-link URLs still work, permalink icons still appear

## Scope

- 616 total md files on the wiki
- 19 currently use h3 (3%) — `*/setup/getting-started.md` workflow steps and a handful of `sensor-definitions.md` / `blueprint.md` reference pages
- 21 currently use h4 (3.4%)
- 95%+ of pages see no visible change

## Test plan

- [ ] CloudCannon preview on `dev` renders normally
- [ ] On a page with h3 headings (e.g. ESPHome Starter Kit → Getting Started), the integrated left-nav TOC no longer shows h3 entries
- [ ] The same h3 headings still render on the page with their `¶` permalink icon and clickable anchor