### PR TITLE
Sync dev to main: TOC depth cap

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,6 +155,7 @@ markdown_extensions:
 #brandon added this 3/26/25
   - toc:
       permalink: true
+      toc_depth: 2
       slugify: !!python/object/apply:pymdownx.slugs.slugify
         kwds:
           case: lower


### PR DESCRIPTION
Publish-sync PR from dev to main.

Includes [ApolloAutomation/docs#784](https://github.com/ApolloAutomation/docs/pull/784): cap the integrated sidebar TOC at h2 so h3+ headings stop crowding the left nav.