### PR TITLE
chore(toc): bump sidebar TOC depth from 2 to 3

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,7 +155,7 @@ markdown_extensions:
 #brandon added this 3/26/25
   - toc:
       permalink: true
-      toc_depth: 2
+      toc_depth: 3
       slugify: !!python/object/apply:pymdownx.slugs.slugify
         kwds:
           case: lower


### PR DESCRIPTION
## Summary

Walks back [#784](https://github.com/ApolloAutomation/docs/pull/784) (`toc_depth: 2`) to `toc_depth: 3`.

Depth 2 was too aggressive: it hid h3 sidebar entries on the 19 files that use h3 as legitimate navigation (`sensor-definitions.md` per product, `getting-started.md` pages, landing pages). Restoring those would have meant promoting headings across ~30-100 pages.

Depth 3 returns those pages to their pre-change state with a one-line change, while still trimming the deepest h4 noise on pages like `plt1-sensor-definitions.md` (17 h4) and `general/faq.md` (10 h4).

## What changes

- **h2 and h3** → sidebar entries (back to pre-#784 behavior on 19 files)
- **h4, h5, h6** → no sidebar entry (still render on the page, still get anchor IDs, deep-link URLs still work)

## Test plan

- [ ] CloudCannon preview on `dev` rebuilds cleanly
- [ ] `products/ESPHome-Starter-Kit/setup/getting-started/` shows h3 entries ("Fill in your Wi-Fi secrets", "Add a new device", "Connect the C6") in the integrated left-nav sidebar again
- [ ] `products/air1/setup/sensor-definitions/` shows its h3 group entries (Controls, Sensors, Configuration, Diagnostic) again
- [ ] `products/general/faq/` still has its h4 Q&A entries hidden from the sidebar (confirms depth is 3, not 6)
- [ ] On-page permalink ¶ icons still render on all heading levels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced table of contents display with deeper nesting levels to improve documentation navigation and structure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ApolloAutomation/docs/pull/786)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->