### PR TITLE
Sync dev to main: TOC depth back to 3

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/tutorials/using-secrets.md
+++ b/docs/products/ESPHome-Starter-Kit/tutorials/using-secrets.md
@@ -1,27 +1,29 @@
 ---
 title: Using secrets.yaml
-description: Store API encryption keys, OTA passwords, MQTT credentials, and more in a single secrets.yaml file so they stay out of your device configs.
+description: >-
+  Store API encryption keys, OTA passwords, MQTT credentials, and more in a
+  single secrets.yaml file so they stay out of your device configs.
 ---
-# Using `secrets.yaml`
+# Using Secrets
 
-In [Getting Started](../setup/getting-started.md) you saved your Wi-Fi name and password in `secrets.yaml`. That same file can hold every other sensitive value your device needs, from your Home Assistant API key to your MQTT password. This tutorial walks through what to put in there and how to reference it from your device YAML.
+In [Getting Started](../setup/getting-started.md) you saved your Wi-Fi name and password in secrets.yaml. That same file can hold every other sensitive value your device needs, from your Home Assistant API key to your MQTT password. This tutorial walks through what to put in there and how to reference it from your device YAML.
 
 ---
 
-## What `secrets.yaml` is
+### What secrets.yaml is
 
-`secrets.yaml` is a single file in ESPHome Device Builder that stores values you don't want pasted into every device config. Two reasons to use it:
+secrets.yaml is a single file in ESPHome Device Builder that stores values you don't want pasted into every device config. Two reasons to use it:
 
 * **Safety.** You can copy a device YAML to a friend, paste it in a forum, or commit it to a public repo without leaking your Wi-Fi password or API key.
-* **One place to change things.** Rotate a password once in `secrets.yaml` and every device that references it picks up the new value on the next flash.
+* **One place to change things.** Rotate a password once in secrets.yaml and every device that references it picks up the new value on the next flash.
 
-`secrets.yaml` lives inside ESPHome Device Builder, so the same secrets are available to every device you build there.
+secrets.yaml lives inside ESPHome Device Builder, so the same secrets are available to every device you build there.
 
 ---
 
-## 1. Open `secrets.yaml`
+### 1\. Navigating to Secrets
 
-In the ESPHome Device Builder dashboard, click **Secrets** in the top right.
+In the ESPHome Device Builder dashboard, click the 3 dots menu in the top right then **Secrets.**
 
 ![](../../../assets/esphome-device-builder-click-secrets.gif)
 
@@ -31,9 +33,9 @@ You'll see a YAML file with one key per line. If you followed Getting Started yo
 
 ---
 
-## 2. The syntax
+### 2\. The syntax
 
-Each entry in `secrets.yaml` is a `key: "value"` pair:
+Each entry is a `key: "value"` pair:
 
 ```yaml
 my_secret_name: "the value goes here"
@@ -45,7 +47,7 @@ In your device YAML, reference it with `!secret` followed by the key name:
 some_option: !secret my_secret_name
 ```
 
-When the device compiles, ESPHome substitutes the value from `secrets.yaml` in place of the `!secret` tag.
+When the device compiles, ESPHome substitutes the value from secrets.yaml in place of the `!secret` tag.
 
 !!! warning "The key has to exist"
 
@@ -53,15 +55,15 @@ When the device compiles, ESPHome substitutes the value from `secrets.yaml` in p
 
 ---
 
-## 3. What to put in `secrets.yaml`
+### 3\. What to put in Secrets
 
-Each section below shows the line you add to `secrets.yaml` and the line in your device YAML that references it.
+Each section below shows the line you add to secrets.yaml and the line in your device YAML that references it.
 
-### Wi-Fi credentials
+#### Wi-Fi credentials
 
 You set these up in [Getting Started](../setup/getting-started.md). They're the baseline every device needs.
 
-In `secrets.yaml`:
+In secrets.yaml:
 
 ```yaml
 wifi_ssid: "your-wifi-ssid-here"
@@ -76,11 +78,11 @@ wifi:
   password: !secret wifi_password
 ```
 
-### Fallback hotspot password
+#### Fallback hotspot password
 
 If you want the device's fallback hotspot to require a password instead of being open, store that here too.
 
-In `secrets.yaml`:
+In secrets.yaml:
 
 ```yaml
 ap_password: "fallback-hotspot-password"
@@ -97,11 +99,11 @@ wifi:
     password: !secret ap_password
 ```
 
-### Home Assistant API encryption key
+#### Home Assistant API encryption key
 
-ESPHome encrypts the connection between your device and Home Assistant. The key is a 32-byte base64 string. The easiest way to get one is to let ESPHome Device Builder generate it for you when you first add the `api:` block, then copy that value into `secrets.yaml`.
+ESPHome encrypts the connection between your device and Home Assistant. The key is a 32-byte base64 string. The easiest way to get one is to let ESPHome Device Builder generate it for you when you first add the `api:` block, then copy that value into secrets.yaml.
 
-In `secrets.yaml`:
+In secrets.yaml:
 
 ```yaml
 api_encryption_key: "your-32-byte-base64-key-here"
@@ -119,11 +121,11 @@ api:
 
     Using the same `api_encryption_key` for every Apollo device on your network is fine and keeps your secrets file short. Home Assistant prompts for the key the first time it discovers a device, then remembers it.
 
-### OTA password
+#### OTA password
 
 OTA (over-the-air) updates let you re-flash a device wirelessly after the first USB flash. The password protects that endpoint so a stranger on your network can't push firmware to your device.
 
-In `secrets.yaml`:
+In secrets.yaml:
 
 ```yaml
 ota_password: "a-long-random-string"
@@ -137,11 +139,11 @@ ota:
     password: !secret ota_password
 ```
 
-### Web server username and password
+#### Web server username and password
 
 If you enable the optional `web_server:` component to access your device at `http://device-name.local/`, you can require a login.
 
-In `secrets.yaml`:
+In secrets.yaml:
 
 ```yaml
 web_server_username: "admin"
@@ -158,11 +160,11 @@ web_server:
     password: !secret web_server_password
 ```
 
-### MQTT broker, username, and password
+#### MQTT broker, username, and password
 
-If you publish to an MQTT broker instead of (or in addition to) the Home Assistant API, all three of these belong in `secrets.yaml`.
+If you publish to an MQTT broker instead of (or in addition to) the Home Assistant API, all three of these belong in secrets.yaml.
 
-In `secrets.yaml`:
+In secrets.yaml:
 
 ```yaml
 mqtt_broker: "192.168.1.50"
@@ -181,9 +183,9 @@ mqtt:
 
 ---
 
-## 4. A complete `secrets.yaml` example
+### 4\. A complete Secrets example
 
-Putting it all together, a fully loaded `secrets.yaml` looks like this:
+Putting it all together, a fully loaded secrets.yaml looks like this:
 
 ```yaml
 # Wi-Fi
@@ -211,16 +213,10 @@ You don't have to include every entry. If a device doesn't use MQTT, leave those
 
 ---
 
-## Good practice
+### Good practice
 
-!!! info "Treat `secrets.yaml` like a password manager"
+!!! info "Treat secrets.yaml like a password manager"
 
     * Don't share or post the file. Share device YAMLs instead, the `!secret` references are safe.
     * Keep a backup somewhere safe (a password manager works well). If you reinstall ESPHome Device Builder you'll need to recreate it.
     * Rotating a credential is a one-line edit here, then re-flash anything that uses it.
-
-## Next steps
-
-* Re-flash your device in ESPHome Device Builder after editing `secrets.yaml` so the new values take effect.
-* Browse [Apollo's other product wikis](https://wiki.apolloautomation.com) for examples of these secrets in real device configs.
-* Join the [Apollo Discord](https://link.apolloautomation.com/discord) if you get stuck.

--- a/docs/products/ESPHome-Starter-Kit/tutorials/using-secrets.md
+++ b/docs/products/ESPHome-Starter-Kit/tutorials/using-secrets.md
@@ -10,7 +10,7 @@ In [Getting Started](../setup/getting-started.md) you saved your Wi-Fi name and 
 
 ---
 
-### What secrets.yaml is
+#### What secrets.yaml is
 
 secrets.yaml is a single file in ESPHome Device Builder that stores values you don't want pasted into every device config. Two reasons to use it:
 
@@ -213,7 +213,7 @@ You don't have to include every entry. If a device doesn't use MQTT, leave those
 
 ---
 
-### Good practice
+#### Good practice
 
 !!! info "Treat secrets.yaml like a password manager"
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,7 +155,7 @@ markdown_extensions:
 #brandon added this 3/26/25
   - toc:
       permalink: true
-      toc_depth: 2
+      toc_depth: 3
       slugify: !!python/object/apply:pymdownx.slugs.slugify
         kwds:
           case: lower


### PR DESCRIPTION
Publish-sync PR from dev to main.

Includes [ApolloAutomation/docs#786](https://github.com/ApolloAutomation/docs/pull/786): walks the sidebar TOC depth cap back from 2 to 3, restoring h3 sidebar entries on the 19 pages that use h3 as legitimate navigation.