### PR TITLE
docs: promote h4 sections to h3 for sidebar visibility

### DIFF
--- a/docs/products/general/faq.md
+++ b/docs/products/general/faq.md
@@ -4,58 +4,58 @@ description: Frequently Asked Questions.
 ---
 # F.A.Q. ~ Frequently Asked Questions
 
-#### 1\. How much power do your sensors use?
+### 1\. How much power do your sensors use?
 
 * All apollo sensors use 1amp or less, some of them 350-500mA.
 
 ---
 
-#### 2\. What all can the MSR-2 LD2410B mmWave sensor go through?
+### 2\. What all can the MSR-2 LD2410B mmWave sensor go through?
 
 * It can reliably go through drywall and some other materials such as thin wood and some couches.
 
 ---
 
-#### 3\. My MSR-2 is triggering and no one is there.
+### 3\. My MSR-2 is triggering and no one is there.
 
 * We have seen this happen before - please first try to restart your radar, then factory reset your radar, then try a factory firmware flash. We also see success with users re-seating their LD2410B mmWave sensor.
 
 ---
 
-#### **3\. How do I reset my Wi-Fi?**
+### **3\. How do I reset my Wi-Fi?**
 
 * Plug in your device then hold down the boot button for 10 seconds. The Wi-Fi credentials should be reset and it will broadcast its hotspot again.
 
 ---
 
-#### **4\. My lux sensor doesn't seem to be working how do I fix it?**
+### **4\. My lux sensor doesn't seem to be working how do I fix it?**
 
 * The default update\_interval is 60 seconds which isnt great for automations revolving around measuring lux values. [Please follow this short guide](https://wiki.apolloautomation.com/products/general/tutorials/how-to-edit-your-sensor's-lux-update-interval/ "How to Edit your lux sensor update interval") to edit the lux update\_interval down to a more responsive 3-5seconds.
 
 ---
 
-#### **5\. Do I need to push the "Clean" button for my Air-1 or setup an automation for it?**
+### **5\. Do I need to push the "Clean" button for my Air-1 or setup an automation for it?**
 
 * No, your Air-1 will self-clean once a week per this [recommended documentation from the manufacturer.](https://sensirion.com/media/documents/6791EFA0/62A1F68F/Sensirion_Datasheet_Environmental_Node_SEN5x.pdf)
 
 ---
 
-#### **6\. Can your sensors be used with OpenHAB?**
+### **6\. Can your sensors be used with OpenHAB?**
 
 * Yes, please install [this binding](https://github.com/seime/openhab-esphome "OpenHAB-ESPHome") and then restart OpenHAB and our devices will show up to configure!
 
 ---
 
-#### **7\. I am getting the error "Failed to import device" in ESPHome Dashboard when trying to adopt my Apollo device.**
+### **7\. I am getting the error "Failed to import device" in ESPHome Dashboard when trying to adopt my Apollo device.**
 
 * Make sure you have enough free space in Home Assistant - Protip: check for old backups you can delete!
 * If your space is not an issue then please reboot or even try reinstalling the ESPHome Device Builder app and see if that helps!
 
 ---
 
-#### **8\. My CO2 values are way off from my other Apollo devices.**
+### **8\. My CO2 values are way off from my other Apollo devices.**
 
-#### **Answer 8:**
+### **Answer 8:**
 
 * If your sensor is exposed to high levels of vibrations or too much airflow, the SCD40 CO2 sensor will have issues working properly. https://sensirion.com/products/catalog/SCD40
 

--- a/docs/products/general/setup/bluetooth-proxy.md
+++ b/docs/products/general/setup/bluetooth-proxy.md
@@ -6,7 +6,7 @@ description: Tutorial for how to turn your Apollo device into a BLE proxy!
 
 This guide shows you how to make your Apollo device act as a "BLE Proxy" which lets Bluetooth devices talk back to home assistant using Apollo devices as the "next hop"!
 
-#### Method 1: Switch to \_BLE.yaml fork
+### Method 1: Switch to \_BLE.yaml fork
 
 1\. Open the Esphome Device Builder.
 
@@ -57,7 +57,7 @@ packages:
 
 ---
 
-#### Method 2: Manually enter the BLE proxy yaml
+### Method 2: Manually enter the BLE proxy yaml
 
 1\. Open the Esphome Device Builder.
 

--- a/docs/products/general/temp-hum-calibration.md
+++ b/docs/products/general/temp-hum-calibration.md
@@ -4,7 +4,7 @@ description: Temp and Humidity Calibration and Offset Examples.
 ---
 # Simple and Advanced Examples of Temperature & Humidity Offsets
 
-#### **Simple Offsets for Temperature and Humidity:**
+### **Simple Offsets for Temperature and Humidity:**
 
 **Please add these to the bottom of your esphome yaml for your device then click save and install. Once you are finished, you will have two new boxes inside the home assistant esphome integration device page for your device where you can fill in an offset. Give them up to 1minute to take effect!**
 
@@ -49,11 +49,11 @@ number:
     mode: box
 ```
 
-#### **BME280 & SCD40 Sensors: Overcoming Temperature & Humidity Reading Challenges**
+### **BME280 & SCD40 Sensors: Overcoming Temperature & Humidity Reading Challenges**
 
 The BME280 and SCD40 sensors are known for their precision in measuring temperature and humidity. However, like all sensor systems, they can sometimes provide inaccurate readings due to various factors. In the case of the BME280 and SCD40 sensors, one significant challenge arises from the heat produced by the ESP chip, which can alter the environment inside its enclosure, thereby skewing the readings.
 
-#### **Adjusting the BME280 and SCD40 Temperature Offset**
+### **Adjusting the BME280 and SCD40 Temperature Offset**
 
 For users who want to fine-tune their sensors, the BME280 and SCD40 Temperature Offset entities can be manually adjusted to match the conditions in their home. The offset values are subtracted from the raw temperature & humidity readings in the firmware to update the sensor readings in the home assistant entity. For example: scd40\_temperature entity = raw scd40 temperature reading - scd40\_offset.   
   
@@ -61,7 +61,7 @@ By default, these offsets are preset to values based on our NIST certified therm
   
 Users will also notice the `bme280_humidity_calibrated`, `scd40_humidity_calibrated`, `bme280_temperature_calibrated`, and `scd40_temperature_calibrated`entities. These values utilize the linear filter in the ESPHome firmware to adjust the readings based on our collected data. Again, due to environmental differences, these might not always be precise.
 
-#### **Modeling the Relationship Between Sensors**
+### **Modeling the Relationship Between Sensors**
 
 Another approach to getting accurate readings is to model the relationship between the ESP temperature and the other sensors compared against a reference temperature. This can be achieved by creating a template sensor in Home Assistant that employs a decision tree or our regression coefficients.
 
@@ -134,10 +134,10 @@ notify:
 ```
 
 
-#### **The Interrelation of Temperature and Humidity**
+### **The Interrelation of Temperature and Humidity**
 
 It's important to understand that temperature and humidity share an interdependent relationship. When the air temperature rises, its capacity to hold moisture increases, which can decrease relative humidity levels. Conversely, when the temperature falls, the air's capacity to hold moisture decreases, leading to increased humidity. This relationship plays a significant role in how sensors detect and interpret readings, making it even more crucial to ensure accuracy.
 
-#### **Advanced Accuracy with GPIO**
+### **Advanced Accuracy with GPIO**
 
 For those seeking the highest accuracy, an advanced solution is available. The exposed mezzanine connector on the back of our Apollo boards can be utilized to connect a temperature/humidity sensor. This modification can dramatically improve both temperature and humidity readings, providing data that's as accurate as possible.

--- a/docs/products/led1/setup/getting-started-led1.md
+++ b/docs/products/led1/setup/getting-started-led1.md
@@ -6,7 +6,7 @@ description: Getting started with your new LED-1!
 
 Congrats on your new LED-1! Below we will go through steps to get you up and running in no time.
 
-#### Choose how to power it
+### Choose how to power it
 
 The LED-1 can be powered via USB (5V up to 3 amps) or via USB Power Delivery (5V or 12V up to 3 amps) or a dedicated power supply using either 5V, 12V, or 24V.
 
@@ -40,7 +40,7 @@ The LED-1 can be powered via USB (5V up to 3 amps) or via USB Power Delivery (5V
 
         Before proceeding to the next steps, make sure to unplug your device!
 
-#### Wire up LEDs
+### Wire up LEDs
 
 !!! danger "Before proceeding, consider double checking your power supply and leds use the same voltage!"
 
@@ -54,7 +54,7 @@ The LED-1 can be powered via USB (5V up to 3 amps) or via USB Power Delivery (5V
 
 3\. Repeat step 2 for a second led strip using Output 2 if you have a second led strip!
 
-#### Connect to Wi-Fi
+### Connect to Wi-Fi
 
 Your device is now ready to connect to your Wi-Fi and begin controlling via Home Assistant, the WLED app for iPhone and Android, or via a web browser!
 
@@ -62,7 +62,7 @@ Your device is now ready to connect to your Wi-Fi and begin controlling via Home
 
 ![](/assets/led-1-getting-started-pic-1.png)
 
-#### Join to Home Assistant
+### Join to Home Assistant
 
 1\. Your device should be auto-discovered by Home Assistant using the WLED Integration as shown below!
 

--- a/docs/products/m1/setup/getting-started-m1-esphome.md
+++ b/docs/products/m1/setup/getting-started-m1-esphome.md
@@ -10,13 +10,13 @@ description: Getting started with your new M-1 running the hub75-studio ESPHome 
 
 This guide walks you through replacing the stock WLED-MM firmware with [hub75-studio](https://github.com/pavlov-net/hub75-studio), an ESPHome firmware tailored for the M-1, and getting it onto your home network and into Home Assistant.
 
-#### Attach M-1 LED Controller
+### Attach M-1 LED Controller
 
 Your M-1 LED Matrix and M-1 controller were shipped separately to minimize damage in shipping. Gently attach the controller to the back of the M-1 LED Matrix panel as shown in the GIF below.
 
 ![](/assets/m1-matrix-attach-controller.webp)
 
-#### Flash the firmware
+### Flash the firmware
 
 !!! success "Use the Rev6 build unless you have an older M-1 Controller!"
 
@@ -34,7 +34,7 @@ Once the firmware finishes installing, the panel displays the **M-1 BIOS** splas
 
 ![](../../../assets/m-1-esphome-firmware-installed-no-wifi.jpg)
 
-#### Connect to Wi-Fi
+### Connect to Wi-Fi
 
 1\. On your phone, open Wi-Fi settings and join the network **apollo-m1-r6-XXXXXX**, where the last 6 characters match the MAC suffix shown on the BIOS screen.
 
@@ -46,7 +46,7 @@ Once the firmware finishes installing, the panel displays the **M-1 BIOS** splas
 
 ![](../../../assets/m-1-esphome-firmware-wifi-connected.jpg)
 
-#### Join to Home Assistant
+### Join to Home Assistant
 
 !!! tip "Your device should be auto-discovered by Home Assistant using the ESPHome Integration as shown below!"
 
@@ -58,9 +58,9 @@ Head to the <a href="http://homeassistant.local:8123/config/integrations" target
 
 ![](../../../assets/m-1-esphome-firmware-add-to-esphome-integration.gif)
 
-#### Optional Features
+### Optional Features
 
-###### Adopt into ESPHome Device Builder
+#### Adopt into ESPHome Device Builder
 
 !!! tip "Required for advanced customization"
 
@@ -96,7 +96,7 @@ wifi_password: "your-wifi-password-here"
 
 ![](../../../assets/esphome-device-builder-finished-installing.gif)
 
-###### Media Proxy
+#### Media Proxy
 
 The <a href="https://github.com/pavlov-net/media-proxy" target="_blank" rel="noreferrer nofollow noopener">Media Proxy app</a> allows you to view gifs, still images, youtube videos, and even use <a href="https://wiki.apolloautomation.com/products/m1/examples/sendspin/" target="_blank" rel="noreferrer nofollow noopener">Sendspin</a> with album art when using <a href="https://www.music-assistant.io/" target="_blank" rel="noreferrer nofollow noopener">Music Assistant</a>!
 
@@ -120,7 +120,7 @@ The <a href="https://github.com/pavlov-net/media-proxy" target="_blank" rel="nor
 
 [Click here to learn what all you can do with the Media Proxy!](https://wiki.apolloautomation.com/products/m1/examples/media-proxy/){    .md-button .md-button--primary }
 
-###### WizMote Remote
+#### WizMote Remote
 
 The M-1 ESPHome firmware has built-in support for the <a href="https://www.amazon.com/WiZ-Remote-Compatible-Lights-Assistant/dp/B091TGDS6F" target="_blank" rel="noreferrer nofollow noopener">WiZ WizMote</a> remote, so you can change pages, dim the panel, and toggle it on/off without your phone.
 

--- a/docs/products/m1/setup/getting-started-m1.md
+++ b/docs/products/m1/setup/getting-started-m1.md
@@ -10,13 +10,13 @@ description: Getting started with your new M-1 running the stock WLED-MM firmwar
 
 Congrats on your new M-1! Below we will go through steps to get you up and running in no time on the stock WLED-MM firmware.
 
-#### Attach M-1 LED Controller
+### Attach M-1 LED Controller
 
 Your M-1 LED Matrix and M-1 controller were shipped separately to minimize damage in shipping. Gently attach the controller to the back of the M-1 LED Matrix panel as shown in the GIF below.
 
 ![](/assets/m1-matrix-attach-controller.webp)
 
-#### Connect to Wi-Fi
+### Connect to Wi-Fi
 
 Your device is ready to connect to your Wi-Fi and begin controlling via Home Assistant, the WLED app for iPhone and Android, or via a web browser!
 
@@ -30,7 +30,7 @@ Your device is ready to connect to your Wi-Fi and begin controlling via Home Ass
 
     Later, you can use this to access your device at http://apollo-led-matrix.local in a browser instead of using the IP address!
 
-#### Post-Connect Setup
+### Post-Connect Setup
 
 !!! warning "Please complete setup by changing a few settings!"
 
@@ -44,7 +44,7 @@ Your device is ready to connect to your Wi-Fi and begin controlling via Home Ass
 
 ![](/assets/m-1-2d-settings.gif)
 
-#### Join to Home Assistant
+### Join to Home Assistant
 
 !!! tip "Your device should be auto-discovered by Home Assistant using the WLED Integration as shown below!"
 


### PR DESCRIPTION
## Summary

Follow-up to [#786](https://github.com/ApolloAutomation/docs/pull/786) (`toc_depth: 3`). On these pages, h4 was doing real navigation work — FAQ questions, getting-started step names, alternative-method headings, calibration examples. After the depth cap they vanished from the integrated sidebar. Promoting them to h3 puts them back without changing the on-page reading experience.

## Files

| File | Change |
|---|---|
| `products/general/faq.md` | 10 h4 Q&A entries → h3 |
| `products/general/setup/bluetooth-proxy.md` | 2 h4 (Method 1, Method 2) → h3 |
| `products/general/temp-hum-calibration.md` | 6 h4 example blocks → h3 |
| `products/led1/setup/getting-started-led1.md` | 4 h4 steps → h3 |
| `products/m1/setup/getting-started-m1.md` | 4 h4 steps → h3 |
| `products/m1/setup/getting-started-m1-esphome.md` | 5 h4 steps → h3; also the 3 h6 "Optional Features" sub-items promoted to h4 so they sit one level under their parent instead of three |

Only heading levels change. No content edits.

## Out of scope

- `plt1/plt1b-sensor-definitions.md` — has 7 h3 + 17 h4 with a repeated H1; needs a real restructure rather than a mechanical promotion. Brandon is investigating separately.
- Pages with only h5/h6 (boot-mode, teardown, general-tips templates) — those were never useful sidebar entries pre-cap either, leaving alone.

## Test plan

- [ ] CloudCannon preview on `dev` rebuilds cleanly
- [ ] `products/general/faq/` sidebar shows the 10 questions
- [ ] `products/general/setup/bluetooth-proxy/` sidebar shows "Method 1" and "Method 2"
- [ ] Each getting-started page sidebar shows its step names
- [ ] M-1 ESPHome page: "Optional Features" appears as h3 in sidebar; "Adopt into ESPHome Device Builder" / "Media Proxy" / "WizMote Remote" render as h4 on the page but stay out of the sidebar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved FAQ formatting with enhanced visual hierarchy and structural clarity.
  * Updated Bluetooth Proxy setup guide with explicit method labels for better navigation.
  * Reformatted temperature and humidity calibration documentation for improved readability.
  * Enhanced Getting Started guides for LED-1 and M1 products with clearer section organization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ApolloAutomation/docs/pull/788)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->