### PR TITLE
chore: sync dev to main (publish style guide)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# Claude Code instructions for Apollo Docs
+
+When working in this repository, read [STYLE_GUIDE.md](STYLE_GUIDE.md)
+before writing or editing any page content. It is the source of truth
+for tone, language, terminology, and formatting on
+[wiki.apolloautomation.com](https://wiki.apolloautomation.com).
+
+For workflow (branching, previewing, opening PRs), see
+[CONTRIBUTING.md](CONTRIBUTING.md). Key points:
+
+- All edits target the **`dev`** branch, never `main`.
+- Maintainers merge `dev → main` to publish to the live wiki.
+- Run `mkdocs serve` to preview locally before opening a PR.
+- Run `mkdocs build` to catch broken internal links before pushing.
+
+A few of the highest-impact rules from the style guide that AI tools
+get wrong most often:
+
+- Product IDs are uppercase with a hyphen: **AIR-1**, **MTR-1**, never
+  `Air-1` or `air1`.
+- **Apollo addons** (hardware modules) and **Home Assistant apps**
+  (formerly add-ons) are different things. Get them right.
+- **ESPHome** is the only correct casing.
+- No em dashes anywhere.
+- Second person, imperative voice for action copy. Wrap numbered steps
+  with framing copy (what the reader unlocks, what success looks like).
+
+Read the full guide before making non-trivial changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,10 +45,22 @@ mkdocs serve
 6. Use PR title format: `<type>: <description>` (types: `docs`, `fix`, `feat`, `chore`)
 
 ## Doc Standards
+
+The full writing and formatting rules live in [STYLE_GUIDE.md](STYLE_GUIDE.md). Read it before opening a non-trivial PR. The highlights:
+
+- **Tone**: respectful, confident, direct, empowering. Avoid corporate filler ("powerful", "seamlessly", "simply").
+- **Voice**: second person, imperative. "Click **Save**", not "you should click save".
+- **Product naming**: `AIR-1`, `MTR-1`, `MSR-2`, etc. uppercase with hyphen, always.
+- **Terminology**: Apollo hardware **addons** and Home Assistant software **apps** are different things; use each in its own context.
+- **ESPHome** is the only correct casing.
+- **No em dashes** anywhere in user-facing copy.
+
+Mechanical conventions:
 - MkDocs Material: see https://squidfunk.github.io/mkdocs-material/ for admonitions, tabs, and content tabs syntax
 - Snippets: when including parts of a file with `--8<-- "file.md:N:"`, start at line 5 to skip YAML front matter
 - Images: place in `docs/assets/`, keep under 750px wide where possible (CI auto-resizes, but smaller source files render faster)
 - Internal links: use site-relative paths so they work in the published site
+- Front matter: every page needs at least `title:` and `description:`
 
 ## Contact & Support
 - **Issues**: GitHub Issues for bugs and improvement requests

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,379 @@
+# Apollo Docs Style Guide
+
+This guide governs the writing and formatting of pages on
+[wiki.apolloautomation.com](https://wiki.apolloautomation.com). It is the
+single source of truth for tone, language, and structural conventions.
+Contributors, maintainers, and AI tools (Claude, Copilot, etc.) all read
+from this file.
+
+For workflow (how to fork, branch, preview, and open a PR), see
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
+> **A note for contributors:** this guide gives prescriptive rules to keep
+> the docs consistent. The "avoid" lists below apply to **user-facing
+> prose**, not to this style guide or other internal documents. Telling a
+> contributor "never use em dashes" is a rule, not a violation of the
+> rule.
+
+---
+
+## Tone of voice
+
+| Aim for | Avoid |
+| --- | --- |
+| Respectful | Patronising |
+| Confident | Boastful |
+| Enthusiastic | Breathless |
+| Direct | Corporate |
+| Empowering | Instructional |
+
+The "empowering, not instructional" line is the one most contributors
+trip over. Numbered steps are unavoidable in technical docs, but a wall
+of imperatives reads as bossy. Wrap procedures with framing copy that
+explains what the reader is about to unlock (see
+[Numbered steps and framing](#numbered-steps-and-framing) below).
+
+## Language to use
+
+Use these phrases consistently. They are part of the Apollo voice.
+
+- **Build, learn, automate**: the organising framework
+- **Your home, your way**: ownership and personalisation
+- **On your own terms**: independence and choice
+- **Real, working device**: tangible outcome
+- **Just the beginning**: opens up possibility without overpromising
+- **Local control**: an HA-audience touchstone that signals values
+- **Open standards**: credibility and trust
+- **Step by step**: structured, guided
+- **ESPHome ecosystem**: positions the kit within a bigger world
+
+When using **open standards** or **local control** for the first time on
+a page, follow with the canonical plain-language explanation below.
+Readers new to the space need the translation, and using the same line
+across the wiki reinforces the message.
+
+- **Local control**: your home runs on your own network. Your devices
+  keep working even if your internet goes down or Apollo goes away.
+- **Open standards**: Apollo builds on public protocols like ESPHome
+  and OpenThread, so your kit is never locked to one vendor.
+
+## Language to avoid
+
+| Don't say | Why | Use instead |
+| --- | --- | --- |
+| Beginner, basic | Patronising | "Getting started", "First boot" |
+| Easy on its own | Vague | Qualify: "easy if you already have X" |
+| Simply, just | Dismissive | Drop the word entirely |
+| Powerful | Cliché | Describe what it actually does |
+| Seamlessly | Cliché | Describe the specific behaviour |
+| Genuinely, honestly | Undermines credibility | Drop the word entirely |
+| "Coding without context" | Intimidating | Say what's actually required |
+| Excessive "no" framing | Negative tone | Rephrase positively |
+
+---
+
+## Product and terminology
+
+### Product IDs
+
+Product IDs are always uppercase with a hyphen: **AIR-1**, **MTR-1**,
+**MSR-2**, **BTN-1**, **PLT-1**, **R-PRO-1**, **TEMP-1**, **LED-1**,
+**M-1**, **PUMP-1**.
+
+Never `Air-1`, `air1`, or `AIR1` in body copy. mkdocs.yml is the source
+of truth for the canonical form.
+
+### First mention per page
+
+On the first mention of a product in body copy, use the full brand name:
+**Apollo AIR-1**. After that, the short form **AIR-1** is fine for the
+rest of the page. Very short pages (a single intro paragraph, an FAQ
+entry) may use the short form throughout.
+
+### Apollo addons vs Home Assistant apps
+
+Two different things share the same word and they are not interchangeable:
+
+- **Apollo addons** are physical hardware modules (the CO2 sensor for
+  AIR-1, etc.). Write **addon** or **addons**, lowercase, no hyphen.
+- **Home Assistant apps** are the software formerly called add-ons. Home
+  Assistant renamed them to apps in 2025. Write **app** or **App Store**.
+
+A page about installing the CO2 hardware addon AND configuring it via a
+Home Assistant app will use both terms. Each is correct in its own
+context.
+
+The forms `add-on`, `Add-on`, and `Addon` should not appear in
+user-facing copy unless quoting upstream documentation.
+
+### ESPHome
+
+Always capitalised exactly **ESPHome**. Never `esphome`, `ESPhome`,
+`Esphome`, or `ESPHOME`. This matches the upstream project's own brand.
+
+When introducing the broader project, prefer **ESPHome ecosystem** over
+"the ESPHome project" or "ESPHome firmware".
+
+### Flashing firmware
+
+**Flash** is the preferred verb for putting firmware on a device:
+
+> Flash your AIR-1 with the latest firmware.
+
+**Install firmware** is acceptable when "flash" would be confusing
+context (for example, when the audience may not recognise the term).
+Avoid **burn** and **load**.
+
+---
+
+## Voice and structure
+
+### Second person, imperative
+
+Default to second person addressed to the reader, with imperative verbs
+in action copy.
+
+> Click **Save**. Plug in your AIR-1. Open the **ESPHome Device Builder
+> app** from your sidebar.
+
+Avoid:
+
+- First person plural: "we'll now configure..."
+- Hedging modal: "you should click..."
+- Passive: "the device is plugged in..."
+
+### Headings
+
+Every page has exactly one H1, which is taken from the page's front
+matter `title`. Markdown body content starts at H2.
+
+All headings use sentence case. The first word is capitalised, and
+proper nouns are capitalised. Everything else is lowercase.
+
+| Yes | No |
+| --- | --- |
+| Connecting through hotspot | Connecting Through Hotspot |
+| Your first automation | Your First Automation |
+| Getting started with AIR-1 | Getting Started With Air-1 |
+
+### Heading levels and the sidebar
+
+mkdocs-material integrates each page's TOC into the left sidebar, and
+`toc_depth` is set to `3` in `mkdocs.yml`. That means **only H2 and H3
+headings appear in the sidebar**. Plan your headings with that in mind:
+
+- **H1**: the page title, taken from the front matter `title`. Exactly
+  one per page, and the body never starts with another H1.
+- **H2**: major sections. Each H2 becomes a sidebar entry, so use them
+  for things a reader might jump to ("Connecting through hotspot",
+  "Troubleshooting").
+- **H3**: subsections that still deserve a sidebar entry. Use
+  sparingly. A page with a dozen H3s under one H2 floods the sidebar.
+- **H4 and below**: in-page detail only. They render in the body but
+  stay out of the sidebar.
+
+If you find yourself wanting an H4 to show up in the sidebar, the right
+move is usually to promote it to H3, or split the page.
+
+### Numbered steps and framing
+
+Any sequence of three or more actions becomes a numbered list. Each step
+starts with an imperative verb.
+
+```markdown
+1. Plug your AIR-1 into power. The LED turns blue.
+2. Open the **Home Assistant** app on your phone.
+3. Tap **Settings → Devices & services → Add integration**.
+```
+
+Sub-steps nest as bullets under the parent number. Do not use
+"Step 1:", "Step 2:" headings.
+
+**Frame the steps.** A bare list of imperatives reads as instructional.
+Lead with a sentence or two on what the reader is about to unlock, and
+follow with a quick success check.
+
+> **Adding your AIR-1 to Home Assistant**
+>
+> Once your sensor is on Wi-Fi, Home Assistant will discover it
+> automatically. This is where your AIR-1 becomes a real, working device
+> in your dashboard.
+>
+> 1. ...
+> 2. ...
+> 3. ...
+>
+> Your AIR-1 now shows up under **Settings → Devices**. From here, every
+> reading the sensor takes flows into Home Assistant in real time.
+
+Banned softeners inside steps: **simply**, **just**, **easy**. These
+either patronise the reader or pad the sentence.
+
+### Front matter
+
+Every page has YAML front matter with at minimum a `title` and a
+`description`:
+
+```yaml
+---
+title: Adding a CO2 addon to your AIR-1
+description: Step-by-step guide to installing the CO2 sensor module and seeing readings in Home Assistant.
+---
+```
+
+- `title` shows in the browser tab, the nav, and the H1.
+- `description` is used by mkdocs for search snippets and social card
+  previews. Skipping it hurts both.
+
+---
+
+## Formatting conventions
+
+### UI labels
+
+Buttons, menu items, tabs, and other on-screen labels are formatted in
+**bold**. Multi-step navigation uses the Unicode right arrow `→`.
+
+> Open **Settings → Devices & services → Add integration** and search
+> for **Apollo**.
+
+Do not use backticks, quotes, or italics for UI elements.
+
+### Code identifiers
+
+Anything the reader types literally or sees in a code-shaped context
+goes in backticks. This includes:
+
+- Entity IDs: `sensor.air1_co2`
+- YAML keys and paths: `wifi.ssid`, `esphome.name`
+- File paths: `/config/configuration.yaml`
+- Shell commands: `esphome run`
+- Config values: `power_save_mode: none`
+
+The distinction matters: **bold** means a thing on the screen,
+`backticks` means a literal string.
+
+### Fenced code blocks
+
+Every fenced code block must declare a language for syntax highlighting:
+
+````markdown
+```yaml
+wifi:
+  ssid: !secret wifi_ssid
+```
+````
+
+When the snippet belongs to a specific file, add a title:
+
+````markdown
+```yaml title="configuration.yaml"
+homeassistant:
+  name: My Home
+```
+````
+
+### Images
+
+- Stored under `docs/assets/`.
+- Filenames in kebab-case: `air1-boot-button.jpg`.
+- Every image has descriptive alt text. Alt text describes what the
+  image shows, not what the file is called. Screen readers and broken
+  images both depend on it.
+- Keep source images under 750px wide where possible. CI auto-resizes,
+  but smaller sources render faster.
+
+```markdown
+![AIR-1 boot button highlighted on the underside of the case](/assets/air1-boot-button.jpg)
+```
+
+### Internal links
+
+Internal links use site-relative paths, not absolute
+`https://wiki.apolloautomation.com/...` URLs:
+
+```markdown
+See [getting started](../setup/getting-started.md) for first-boot setup.
+```
+
+Relative links work in PR previews, survive a future domain change, and
+let mkdocs catch broken targets at build time. Links to external sites
+(home-assistant.io, esphome.io) stay absolute.
+
+---
+
+## Punctuation
+
+### Oxford comma
+
+Always use the Oxford comma in lists of three or more items.
+
+> AIR-1 supports Wi-Fi, MQTT, and Bluetooth.
+
+### Em dashes
+
+Do not use em dashes (`—`) anywhere in user-facing copy. Replace with
+commas, periods, parentheses, or "X to Y" for ranges.
+
+| Don't write | Write instead |
+| --- | --- |
+| `The AIR-1 — once flashed — connects automatically.` | `The AIR-1, once flashed, connects automatically.` |
+| `Three sensors — CO2, VOC, and PM2.5 — ship in the kit.` | `Three sensors (CO2, VOC, and PM2.5) ship in the kit.` |
+| `Run the test for 5 — 10 minutes.` | `Run the test for 5 to 10 minutes.` |
+
+### Lists
+
+List items that are complete sentences end with a period. Fragments do
+not.
+
+```markdown
+Features:
+- Real-time CO2 readings
+- Onboard temperature compensation
+- USB-C power
+
+Setup steps:
+- Plug in the device.
+- Wait for the LED to turn green.
+- Open the companion app.
+```
+
+---
+
+## Files and folders
+
+### Filenames
+
+All markdown filenames are kebab-case: `adding-co2-to-air-1.md`. No
+camelCase, no snake_case, no spaces, no capital letters.
+
+### Directory structure
+
+Pages live under per-product subdirectories, mirrored across platform
+trees:
+
+```
+docs/
+├── products/                    Home Assistant tree
+│   └── air1/
+│       ├── setup/
+│       ├── addons/
+│       └── troubleshooting/
+└── homey/products/              Homey tree
+    └── air1/
+        ├── setup/
+        ├── addons/
+        └── troubleshooting/
+```
+
+When a topic exists on both Home Assistant and Homey, use the **same
+filename** in both trees. This makes cross-platform consistency obvious
+to anyone editing the docs.
+
+---
+
+## When in doubt
+
+If a rule above conflicts with clarity for the reader, clarity wins.
+Open an issue or PR proposing the rule change so the guide stays
+honest.


### PR DESCRIPTION
## What does this implement/fix?

Routine `dev → main` sync. Publishes the changes recently merged to `dev`, including PR #794 which adds `STYLE_GUIDE.md`, `CLAUDE.md`, and a CONTRIBUTING.md link to the new style guide.

## Types of changes

- [x] Site config or theme change

## Checklist:

  - [ ] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [x] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [x] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  dev → main sync PR. Targets main intentionally.
-->