### PR TITLE
docs: keep STYLE_GUIDE.md current as conventions emerge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,3 +26,24 @@ get wrong most often:
   with framing copy (what the reader unlocks, what success looks like).
 
 Read the full guide before making non-trivial changes.
+
+## Keep the style guide current
+
+If you notice a recurring pattern that should be standardized but isn't
+in `STYLE_GUIDE.md`, surface it to the user before applying it in the
+current edit. Examples:
+
+- A new product name or capitalization that isn't covered by the
+  naming rules.
+- A formatting convention you're about to use repeatedly (a new
+  admonition type, a new way of showing CLI output) that future
+  contributors should follow.
+- A drift between pages where the guide is ambiguous about which
+  pattern wins.
+
+Propose the addition to `STYLE_GUIDE.md` in the same PR (or a separate
+follow-up if it's substantial). The goal is for the guide to stay ahead
+of the docs, not behind them.
+
+One-off stylistic choices on a single page don't need a suggestion.
+This is about patterns that will repeat.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,8 @@ Mechanical conventions:
 - Internal links: use site-relative paths so they work in the published site
 - Front matter: every page needs at least `title:` and `description:`
 
+If your PR establishes a new convention that isn't in [STYLE_GUIDE.md](STYLE_GUIDE.md) (a new product name, a new formatting pattern you'll want others to follow, a clarification of an ambiguous rule), update the style guide in the same PR. Keeping the guide ahead of the docs is how it stays useful.
+
 ## Contact & Support
 - **Issues**: GitHub Issues for bugs and improvement requests
 - **Email**: support@apolloautomation.com


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

Follow-up to #794. Adds a meta-rule to both `CLAUDE.md` and `CONTRIBUTING.md` telling contributors (human or AI) to update `STYLE_GUIDE.md` when they encounter a recurring pattern the guide doesn't cover. Without this, the guide drifts behind reality as new conventions emerge in individual PRs.

- **CLAUDE.md**: Claude surfaces the gap to the user before applying a new pattern repeatedly.
- **CONTRIBUTING.md**: human contributors bundle the style update into the same PR that introduces the new convention.

Scoped narrowly: this is for *patterns that will repeat*, not one-off stylistic choices on a single page.

## Types of changes

- [ ] Typo / wording fix
- [ ] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [x] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:

  - [x] This PR targets the `dev` branch (not `main`)
  - [ ] Changes previewed locally with `mkdocs serve`
  - [x] If pages were moved or renamed, redirects were added to `mkdocs.yml` (N/A)
  - [x] If new pages were added, nav was updated in `mkdocs.yml` (N/A)

<!--
  Thank you for contributing <3
-->