### PR TITLE
chore: sync dev to main (style guide self-update rule)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,3 +26,24 @@ get wrong most often:
   with framing copy (what the reader unlocks, what success looks like).
 
 Read the full guide before making non-trivial changes.
+
+## Keep the style guide current
+
+If you notice a recurring pattern that should be standardized but isn't
+in `STYLE_GUIDE.md`, surface it to the user before applying it in the
+current edit. Examples:
+
+- A new product name or capitalization that isn't covered by the
+  naming rules.
+- A formatting convention you're about to use repeatedly (a new
+  admonition type, a new way of showing CLI output) that future
+  contributors should follow.
+- A drift between pages where the guide is ambiguous about which
+  pattern wins.
+
+Propose the addition to `STYLE_GUIDE.md` in the same PR (or a separate
+follow-up if it's substantial). The goal is for the guide to stay ahead
+of the docs, not behind them.
+
+One-off stylistic choices on a single page don't need a suggestion.
+This is about patterns that will repeat.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,8 @@ Mechanical conventions:
 - Internal links: use site-relative paths so they work in the published site
 - Front matter: every page needs at least `title:` and `description:`
 
+If your PR establishes a new convention that isn't in [STYLE_GUIDE.md](STYLE_GUIDE.md) (a new product name, a new formatting pattern you'll want others to follow, a clarification of an ambiguous rule), update the style guide in the same PR. Keeping the guide ahead of the docs is how it stays useful.
+
 ## Contact & Support
 - **Issues**: GitHub Issues for bugs and improvement requests
 - **Email**: support@apolloautomation.com


### PR DESCRIPTION
## What does this implement/fix?

Routine `dev → main` sync for PR #796 (adds the self-update meta-rule to CLAUDE.md and CONTRIBUTING.md).

## Types of changes

- [x] Site config or theme change

## Checklist:

  - [ ] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [x] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [x] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  dev → main sync PR. Targets main intentionally.
-->