### PR TITLE
docs: point ESPHome Device Builder install to desktop.esphome.io

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/setup/first-steps.md
+++ b/docs/products/ESPHome-Starter-Kit/setup/first-steps.md
@@ -22,7 +22,7 @@ Pick the platform you'll be running ESPHome Device Builder on:
 
 === "Windows"
 
-    1. <a href="https://github.com/esphome/esphome-desktop/releases/download/v0.7.0/ESPHome.Builder_0.7.0_x64-setup.exe" title="Download the ESPHome Device Builder for Windows" target="_blank" rel="noreferrer nofollow noopener">Download the ESPHome Device Builder for Windows</a>.
+    1. Open <a href="https://desktop.esphome.io" target="_blank" rel="noreferrer nofollow noopener">desktop.esphome.io</a> and click **Download installer** under the **Windows** tab.
     2. Open the installer and click **Next** then click **Next** again to start the installation process. Once it shows completed, click **Next** again then **Finish** to complete the installation.
        * If Windows shows a blue **Windows protected your PC** warning, click **More info → Run anyway** to continue.
 
@@ -40,10 +40,10 @@ Pick the platform you'll be running ESPHome Device Builder on:
 
 === "Mac"
 
-    1. Download the ESPHome Device Builder for Mac. Pick the build that matches your chip:
+    1. Open <a href="https://desktop.esphome.io" target="_blank" rel="noreferrer nofollow noopener">desktop.esphome.io</a>. The page detects your OS and shows the macOS downloads. Pick the build that matches your chip:
 
-        - <a href="https://github.com/esphome/esphome-desktop/releases/download/v0.7.0/ESPHome.Builder_0.7.0_aarch64.dmg" target="_blank" rel="noreferrer nofollow noopener">Apple Silicon (M1, M2, M3, M4)</a>
-        - <a href="https://github.com/esphome/esphome-desktop/releases/download/v0.7.0/ESPHome.Builder_0.7.0_x64.dmg" target="_blank" rel="noreferrer nofollow noopener">Intel Mac</a>
+        - **Apple Silicon** (M1, M2, M3, M4)
+        - **Intel Mac**
 
     2. Open the `.dmg` and drag **ESPHome Builder** into your Applications folder. Launch it from Applications or Spotlight.
 
@@ -83,17 +83,18 @@ Pick the platform you'll be running ESPHome Device Builder on:
 
 === "Linux"
 
-    1. Download the ESPHome Device Builder for Linux. Pick the package that fits your distro:
+    1. Open <a href="https://desktop.esphome.io" target="_blank" rel="noreferrer nofollow noopener">desktop.esphome.io</a>. Under the **Linux** tab, pick the package for your distro:
 
-        - <a href="https://github.com/esphome/esphome-desktop/releases/download/v0.7.0/ESPHome.Builder_0.7.0_amd64.AppImage" target="_blank" rel="noreferrer nofollow noopener">AppImage (works on any distro)</a>
-        - <a href="https://github.com/esphome/esphome-desktop/releases/download/v0.7.0/ESPHome.Builder_0.7.0_amd64.deb" target="_blank" rel="noreferrer nofollow noopener">.deb (Debian / Ubuntu)</a>
-        - <a href="https://github.com/esphome/esphome-desktop/releases/download/v0.7.0/ESPHome.Builder-0.7.0-1.x86_64.rpm" target="_blank" rel="noreferrer nofollow noopener">.rpm (Fedora / RHEL)</a>
+        - **AppImage** (works on any distro)
+        - **.deb** (Debian / Ubuntu)
+        - **.rpm** (Fedora / RHEL)
+        - **AUR** (Arch Linux)
 
     2. Install or run the file you downloaded:
 
-        - **AppImage:** `chmod +x ESPHome.Builder_0.7.0_amd64.AppImage` then double-click the file, or run it from a terminal.
-        - **.deb:** `sudo apt install ./ESPHome.Builder_0.7.0_amd64.deb`
-        - **.rpm:** `sudo dnf install ./ESPHome.Builder-0.7.0-1.x86_64.rpm`
+        - **AppImage:** `chmod +x ESPHome.Builder_*.AppImage` then double-click the file, or run it from a terminal.
+        - **.deb:** `sudo apt install ./ESPHome.Builder_*.deb`
+        - **.rpm:** `sudo dnf install ./ESPHome.Builder*.rpm`
 
     <!-- TODO: add a Linux installer screenshot if available. -->
 


### PR DESCRIPTION
## What does this implement/fix?

The Windows, Mac, and Linux install tabs on the Starter Kit First Steps page hardcoded ESPHome Device Builder v0.7.0 GitHub release URLs and example filenames, which rot every time ESPHome ships a release.

ESPHome now hosts a dedicated downloads page at <https://desktop.esphome.io> that auto-detects the visitor's OS and always serves the latest installer per platform (including AUR for Arch, which was missing from our Linux tab).

Changes:

- Windows, Mac, and Linux tabs: replace pinned GitHub release URLs with prose pointing at desktop.esphome.io.
- Linux step 2: genericise the install command examples with wildcard filenames so they no longer reference `0.7.0`.
- Home Assistant App tab unchanged (desktop.esphome.io does not cover the HA install path).
- Backend Beta toggle steps unchanged for now; will be revisited once the new backend ships as the desktop default.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [x] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [x] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [x] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ESPHome Device Builder setup instructions for Windows, Mac, and Linux to streamline the download process by directing users to desktop.esphome.io, which automatically detects the operating system and provides the appropriate download for each platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ApolloAutomation/docs/pull/840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->