### PR TITLE
Add Button Controlled LEDs tutorial under ESPHome Starter Kit > Automations

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/automations/button-controlled-leds.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/button-controlled-leds.md
@@ -1,0 +1,88 @@
+---
+title: Button Controlled LEDs
+description: >-
+  Build your first automation in the new ESPHome Device Builder GUI: pressing
+  the Button module toggles the RGB module on and off.
+---
+# Build a Button-Controlled RGB Light
+
+This tutorial uses the Button module and the RGB & Buzzer module connected to the ESP32-C6, all sitting in the starter kit case.
+
+<!-- TODO: hero image of the assembled starter kit. Save as docs/assets/esphome-starter-kit-button-rgb-assembled.png -->
+
+!!! note "Before you start"
+
+    Work through these pages first. This tutorial assumes your device is flashed and both modules are connected:
+
+    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps/) to create your starter kit device in ESPHome Device Builder.
+    * [Adding the Button Module](/products/ESPHome-Starter-Kit/modules/button-module/) to wire up the input.
+    * [Adding the LED & Buzzer Module](/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module/) to wire up the RGB output.
+
+## Build the automation
+
+ESPHome Device Builder has a new GUI for building <a href="https://esphome.io/automations/" target="_blank" rel="noreferrer nofollow noopener">automations</a>, so you can wire a trigger to an action without hand-writing YAML. The trigger is the *when* of the automation, the thing that makes it fire. The action is the *then do*, what happens when it fires. If you've built automations in Home Assistant, this is the same mental model.
+
+1.  Open your starter kit device in ESPHome Device Builder and click **Edit**. If you need a refresher on the editor, see the [Device Builder Tour](/products/ESPHome-Starter-Kit/learning-the-basics/device-builder-tour/#editor).
+2.  In the editor's left pane, expand the **Automations** dropdown and click **Add Automation**.
+3.  Set up the trigger:
+
+    <div class="annotate" markdown>
+
+    - **What should this automation react to?** → **A configured component**
+    - **Which configured component?** → **Button Module (binary_sensor.gpio)**
+    - **Which trigger?** → **Binary Sensor → On Click** (1)
+
+    </div>
+
+    1.  The trigger dropdown also offers **On Double Click**, **On Multi Click**, **On Press**, **On Release**, **On State**, and **On State Change** for other button gestures. Swap any of these in once you're comfortable with the On Click flow.
+
+4.  Click **Continue**. You land on the **Binary Sensor → On Click** editor with the **Target** already set to your Button module.
+5.  Set up the action:
+
+    <div class="annotate" markdown>
+
+    - Under **Actions**, click **+ Add action**.
+    - In the **Add action** dialog, stay on the **By target** tab and choose **Light → Toggle** under the RGB LED group.
+    - On the new action, click the **ID** dropdown and select **RGB LEDs**. (1)
+
+    </div>
+
+    1.  The **ID** dropdown only needs changing if your device also has an **Onboard RGB LED** component configured. If **RGB LEDs** is the only light, it's already selected.
+
+??? note "What the GUI built in YAML"
+
+    The form pane and the YAML editor on the right of the editor stay in sync, so the GUI you just used and the YAML pane are two views of the same config. Your button section now grows an `on_click` trigger with a `light.toggle` action:
+
+    ```yaml
+    binary_sensor:
+      - platform: gpio
+        name: Button Module
+        pin:
+          inverted: true
+          mode:
+            input: true
+            pullup: true
+          number: 6
+        id: button_module
+        on_click:
+          then:
+            - light.toggle: rgb_leds
+    ```
+
+    See [Device Builder Tour → YAML editor (right)](/products/ESPHome-Starter-Kit/learning-the-basics/device-builder-tour/#yaml-editor-right) for the full breakdown of the YAML pane.
+
+## Install the firmware
+
+Your automation is saved in Device Builder, but the device is still running its old firmware. Compile and install the new code to push the change.
+
+1. Click **Save** in the bottom right of the editor.
+2. Click **Install**, then pick **On the Network** to push the new firmware over Wi-Fi.
+3. Wait for the compile and flash to finish. The device reboots once the install is done.
+
+## Test the automation
+
+With the device back online, press the button on the Button module. You should hear a soft click, and the RGB LEDs turn on. Press it again and they turn off.
+
+!!! success "You've built your first GUI automation!"
+
+    The same trigger-then-action pattern works for every automation you'll build in Device Builder. Swap the trigger (motion, temperature crossing a threshold, a schedule) or the action (turn on, dim, play a buzzer tone) and you have a new automation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ markdown_extensions:
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
   - attr_list
+  - md_in_html
   - pymdownx.critic
   - pymdownx.caret
   - pymdownx.keys
@@ -512,6 +513,8 @@ nav:
           - Tutorials:
               - Using Secrets: products/ESPHome-Starter-Kit/tutorials/using-secrets.md
               - Connect to Home Assistant: products/ESPHome-Starter-Kit/tutorials/connect-to-home-assistant.md
+          - Automations:
+              - Button Controlled LEDs: products/ESPHome-Starter-Kit/automations/button-controlled-leds.md
           - Learn the Basics:
               - Explaining ESPHome: products/ESPHome-Starter-Kit/learning-the-basics/explaining-esphome.md
               - Device Builder Tour: products/ESPHome-Starter-Kit/learning-the-basics/device-builder-tour.md


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

Adds a new **Automations** group under **ESPHome Starter Kit** in the sidebar, with a first tutorial: **Button Controlled LEDs**. The page walks readers through building an automation in the new ESPHome Device Builder GUI (no YAML by hand) so pressing the Button module toggles the RGB module.

The tutorial covers:

- Opening the editor and starting a new automation
- Setting up the trigger (Binary Sensor → On Click on the Button module) with a collapsible callout for the other button-gesture options
- Setting up the action (Light → Toggle on RGB LEDs) with an inline annotation explaining when the **ID** dropdown needs changing
- A collapsible YAML view of what the GUI built
- Save → Install → On the Network, plus a test step (press the button, hear the click, watch the LEDs toggle)

Effects are deliberately not covered yet because the GUI builder doesn't expose effect selection today.

`mkdocs.yml` changes:

- New `Automations:` group under `ESPHome Starter Kit` with the tutorial wired up
- Adds `md_in_html` to `markdown_extensions` so the `<div class="annotate" markdown>` annotation pattern works for inline notes inside list items (the pattern recommended by the Material annotation docs for nested content)

Screenshot placeholder for the hero image (`esphome-starter-kit-button-rgb-assembled.png`) is left as a `<!-- TODO -->` comment in the page. Will drop the image in a follow-up.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [ ] Content update (correcting outdated info, adding missing steps, clarifications)
- [x] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [x] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a new guide for creating button-controlled LED automations in ESPHome Device Builder, including step-by-step setup instructions, configuration examples, and testing steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ApolloAutomation/docs/pull/852?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->