### PR TITLE
docs: fix Starter Kit spotlight card on mobile

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,17 +11,19 @@ description: >-
     Your go-to resource for setup guides, troubleshooting, and tips for every Apollo device. Found an error or need help? [Open a GitHub issue](https://github.com/ApolloAutomation/docs/issues), hop into our [Discord](https://link.apolloautomation.com/discord), post on our [Community Forum](https://forum.apolloautomation.com/), or email [support@apolloautomation.com](mailto:support@apolloautomation.com).
 
 <style>
-  .apollo-esk-img {
-    position: absolute !important;
-    top: 50% !important;
-    right: 28px !important;
-    transform: translateY(-50%) !important;
-    width: 280px !important;
-    height: 212px !important;
-    object-fit: cover !important;
-    border-radius: 12px !important;
-    display: block !important;
-    max-width: none !important;
+  @media (min-width: 701px) {
+    .apollo-esk-img {
+      position: absolute !important;
+      top: 50% !important;
+      right: 28px !important;
+      transform: translateY(-50%) !important;
+      width: 280px !important;
+      height: 212px !important;
+      object-fit: cover !important;
+      border-radius: 12px !important;
+      display: block !important;
+      max-width: none !important;
+    }
   }
   @media (max-width: 700px) {
     .apollo-esk-card { min-height: 0 !important; padding: 24px !important; }
@@ -32,6 +34,9 @@ description: >-
       width: 100% !important;
       height: 200px !important;
       margin-top: 20px !important;
+      transform: none !important;
+      border-radius: 12px !important;
+      object-fit: cover !important;
       display: block !important;
     }
   }


### PR DESCRIPTION
## Summary

- Wraps the desktop `.apollo-esk-img` overrides in `@media (min-width: 701px)` so they no longer compete with the mobile media query and stop the spotlight card from rendering with a desktop-sized image on phones.
- Adds explicit resets for `transform`, `border-radius`, and `object-fit` inside the existing mobile media query so the stacked banner image renders cleanly under 700px.

## Test plan

- [x] Verify on local `mkdocs serve` at narrow widths that the image stacks below the text as a 200px banner
- [ ] Verify on a real phone that subhead + CTA are visible and the image isn't oversized


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced responsive styling to improve image display consistency across different screen sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ApolloAutomation/docs/pull/854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->