### PR TITLE
Fix Build the automation list mangled by CloudCannon edit

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/automations/button-controlled-leds.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/button-controlled-leds.md
@@ -20,32 +20,35 @@ This tutorial uses the Button module and the RGB & Buzzer module connected to th
 
 ESPHome Device Builder has a new GUI for building <a href="https://esphome.io/automations/" target="_blank" rel="noreferrer nofollow noopener">automations</a>, so you can wire a trigger to an action without hand-writing YAML. The trigger is the *when* of the automation, the thing that makes it fire. The action is the *then do*, what happens when it fires. If you've built automations in Home Assistant, this is the same mental model.
 
-1. Open your starter kit device in ESPHome Device Builder and click **Edit**. If you need a refresher on the editor, see the [Device Builder Tour](/products/ESPHome-Starter-Kit/learning-the-basics/device-builder-tour/#editor).
-2. In the editor's left pane, expand the **Automations** dropdown and click **Add Automation**.
+1.  Open your starter kit device in ESPHome Device Builder and click **Edit**. If you need a refresher on the editor, see the [Device Builder Tour](/products/ESPHome-Starter-Kit/learning-the-basics/device-builder-tour/#editor).
+2.  In the editor's left pane, expand the **Automations** dropdown and click **Add Automation**.
 
-![](../../../assets/esphome-device-builder-add-automation.gif)
+    ![](../../../assets/esphome-device-builder-add-automation.gif)
 
-1. Set up the trigger:
+3.  Set up the trigger:
 
-   <div markdown class="annotate">
+    <div class="annotate" markdown>
 
-          - **What should this automation react to?** → **A configured component**
-          - **Which configured component?** → **Button Module (binary_sensor.gpio)**
-          - **Which trigger?** → **Binary Sensor → On Click** (1)
+    - **What should this automation react to?** → **A configured component**
+    - **Which configured component?** → **Button Module (binary_sensor.gpio)**
+    - **Which trigger?** → **Binary Sensor → On Click** (1)
 
-          </div>
-   1. The trigger dropdown also offers **On Double Click**, **On Multi Click**, **On Press**, **On Release**, **On State**, and **On State Change** for other button gestures. Swap any of these in once you're comfortable with the On Click flow.
-2. Click **Continue**. You land on the **Binary Sensor → On Click** editor with the **Target** already set to your Button module.
-3. Set up the action:
+    </div>
 
-   <div markdown class="annotate">
+    1.  The trigger dropdown also offers **On Double Click**, **On Multi Click**, **On Press**, **On Release**, **On State**, and **On State Change** for other button gestures. Swap any of these in once you're comfortable with the On Click flow.
 
-          - Under **Actions**, click **+ Add action**.
-          - In the **Add action** dialog, stay on the **By target** tab and choose **Light → Toggle** under the RGB LED group.
-          - On the new action, click the **ID** dropdown and select **RGB LEDs**. (1)
+4.  Click **Continue**. You land on the **Binary Sensor → On Click** editor with the **Target** already set to your Button module.
+5.  Set up the action:
 
-          </div>
-   1. The **ID** dropdown only needs changing if your device also has an **Onboard RGB LED** component configured. If **RGB LEDs** is the only light, it's already selected.
+    <div class="annotate" markdown>
+
+    - Under **Actions**, click **+ Add action**.
+    - In the **Add action** dialog, stay on the **By target** tab and choose **Light → Toggle** under the RGB LED group.
+    - On the new action, click the **ID** dropdown and select **RGB LEDs**. (1)
+
+    </div>
+
+    1.  The **ID** dropdown only needs changing if your device also has an **Onboard RGB LED** component configured. If **RGB LEDs** is the only light, it's already selected.
 
 ??? note "What the GUI built in YAML"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

A previous CloudCannon edit (d3e17f8) on `docs/products/ESPHome-Starter-Kit/automations/button-controlled-leds.md` mangled the **Build the automation** section:

- The single 1-5 numbered list was split into two short lists because CloudCannon inserted the new `add-automation.gif` at the top level, between steps 2 and 3.
- The bullets inside both `<div class="annotate" markdown>` blocks were reindented to 10 spaces, which python-markdown then rendered as a single paragraph. The result on the live page is bullets joined inline with literal `-` characters instead of rendering as a list.
- The trailing newline on the file was dropped.

This PR restores the original structure:

- Continuous 1-5 numbered list.
- The new `add-automation.gif` lives inside step 2 with 4-space continuation indent, so it doesn't break list numbering.
- Annotate blocks back to `<div class="annotate" markdown>` with 4-space bullet indent.
- Trailing newline restored.

The two new images CloudCannon added (`add-automation.gif` and `example-rgb-button-automation.webp`, plus the existing `install-button-component.gif`) are kept where they belong.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [x] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [ ] Changes previewed locally with `mkdocs serve`
  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [ ] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the automation setup instructions in the ESPHome Starter Kit button-controlled LEDs guide with clearer step-by-step formatting for configuring trigger and action selections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ApolloAutomation/docs/pull/865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->