### PR TITLE
Add Light Effects tutorial under ESPHome Starter Kit > Tutorials

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/automations/button-controlled-leds.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/button-controlled-leds.md
@@ -88,3 +88,7 @@ With the device back online, press the button on the Button module. You should h
 !!! success "You've built your first GUI automation!"
 
     The same trigger-then-action pattern works for every automation you'll build in Device Builder. Swap the trigger (motion, temperature crossing a threshold, a schedule) or the action (turn on, dim, play a buzzer tone) and you have a new automation.
+
+#### Next Steps
+
+<a href="../../tutorials/light-effects/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Next - Light Effects</a>

--- a/docs/products/ESPHome-Starter-Kit/tutorials/light-effects.md
+++ b/docs/products/ESPHome-Starter-Kit/tutorials/light-effects.md
@@ -1,0 +1,54 @@
+---
+title: Light Effects
+description: >-
+  Add built-in ESPHome light effects (rainbow, color wipe, and more) to your
+  RGB module by pasting a few lines into the Effects field.
+---
+# Add Light Effects to Your RGB Module
+
+Out of the box, your RGB module turns on, turns off, and changes color. ESPHome ships a library of built-in <a href="https://esphome.io/components/light/#light-effects" target="_blank" rel="noreferrer nofollow noopener">light effects</a> (rainbow cycles, color wipes, flickers, and more) that you can drop in with a couple of lines of YAML. This tutorial adds two effects to get you started.
+
+!!! note "Before you start"
+
+    Work through these pages first. This tutorial assumes your device is flashed and has an addressable RGB light component already configured (either the **Onboard RGB LED** or the **RGB LEDs** from the LED & Buzzer module):
+
+    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps/) to create your starter kit device in ESPHome Device Builder.
+    * [Adding the LED & Buzzer Module](/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module/) if you're using the LED & Buzzer module.
+
+## Add the effects
+
+1.  Open your starter kit device in ESPHome Device Builder and click **Edit**.
+2.  In the editor's left pane, scroll to **Components** and click the RGB light you want to add effects to (either **Onboard RGB LED** or **RGB LEDs**).
+3.  Toggle on **Show advanced settings**, then scroll down to the **Effects** field.
+4.  Paste the following into the **Effects** field:
+
+    ```yaml
+    - addressable_rainbow:
+    - addressable_color_wipe:
+    ```
+
+    This adds two effects to the light: a continuously cycling rainbow and a sweeping color wipe.
+
+??? info "Browse more effects"
+
+    ESPHome's full effect library lives at <a href="https://esphome.io/components/light/#light-effects" target="_blank" rel="noreferrer nofollow noopener">esphome.io/components/light</a>. Open it in a new tab and pick anything you want to try.
+
+    The starter kit RGB modules are **addressable** lights (each LED can be controlled individually), so look for effect names that start with `addressable_`. Non-addressable effects like `pulse` or `strobe` will not apply.
+
+## Install the firmware
+
+The effects are saved in Device Builder, but the device is still running its old firmware. Compile and install the new code to push the change.
+
+1.  Click **Save** in the bottom right of the editor.
+2.  Click **Install**, then pick **On the Network** to push the new firmware over Wi-Fi.
+3.  Wait for the compile and flash to finish. The device reboots once the install is done.
+
+## Try the effects
+
+With the device back online, open the local web page at `http://esphome-starter-kit.local/` (or whatever you named your device) in a browser on the same Wi-Fi network. Find the RGB light entity and pick **Rainbow** or **Color Wipe** from the **Effect** dropdown. The LEDs start animating right away.
+
+If you've already followed [Connect to Home Assistant](/products/ESPHome-Starter-Kit/tutorials/connect-to-home-assistant/), the same **Effect** dropdown shows up on the light entity card in Home Assistant.
+
+!!! success "You just edited YAML!"
+
+    Every component you add to your device has a set of advanced fields like this one. Pasting a few lines into the right field is all it takes to unlock more behavior, and the YAML pane on the right of the editor will show you exactly what changed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -514,6 +514,7 @@ nav:
           - Tutorials:
               - Using Secrets: products/ESPHome-Starter-Kit/tutorials/using-secrets.md
               - Connect to Home Assistant: products/ESPHome-Starter-Kit/tutorials/connect-to-home-assistant.md
+              - Light Effects: products/ESPHome-Starter-Kit/tutorials/light-effects.md
           - Automations:
               - Button Controlled LEDs: products/ESPHome-Starter-Kit/automations/button-controlled-leds.md
           - Learn the Basics:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

Adds a new **Light Effects** tutorial under **ESPHome Starter Kit > Tutorials**, alongside Using Secrets and Connect to Home Assistant. The page walks readers through adding two built-in ESPHome light effects (`addressable_rainbow` and `addressable_color_wipe`) by pasting YAML into the **Effects** field on their RGB light component.

The tutorial covers:

- Opening Device Builder, navigating to the RGB light component
- Toggling on **Show advanced settings** and pasting the effects YAML
- Collapsible callout pointing to the full ESPHome effects library and explaining the `addressable_*` requirement for the starter kit RGB
- Save → Install → On the Network
- Trying the effects from the local web server (with a one-liner pointing readers who have done Connect to Home Assistant to the same dropdown on the HA entity card)
- Closing success admonition framing it as the reader's first YAML edit

Also adds a `#### Next Steps` H4 (not in sidebar) at the bottom of Button Controlled LEDs with an ESPHome-styled `md-button` pointing to Light Effects, so the GUI automation reader has a natural follow-up.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [ ] Content update (correcting outdated info, adding missing steps, clarifications)
- [x] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [x] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added a new tutorial page explaining how to add built-in addressable light effects to RGB modules, including step-by-step instructions for pasting effect definitions and verifying effects via the device web UI and Home Assistant.
* Updated an existing tutorial with a "Next Steps" section that provides navigation to the new light effects tutorial.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ApolloAutomation/docs/pull/866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->