### PR TITLE
Add CloudCannon annotation snippet

### DIFF
--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -208,3 +208,36 @@ _snippets:
         label: Button Icon
         comment: >
           Search available icons <a href="https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/#search">here</a>. Remove the colons on each side when pasting.
+#brandon added this for annotations
+  mkdoc_annotation:
+    snippet: "[[annotated_text]] (1)\n{ .annotate }\n\n1.  [[annotation_content]]"
+    preview:
+      text:
+        - key: annotated_text
+        - 'Annotation'
+      subtext:
+        - key: annotation_content
+    picker_preview:
+      text: Annotation
+    params:
+      annotated_text:
+        parser: content
+        options:
+          editor_key: annotated_text
+          style:
+            trim_text: true
+      annotation_content:
+        parser: content
+        options:
+          editor_key: annotation_content
+          style:
+            trim_text: true
+    _inputs:
+      annotated_text:
+        type: text
+        label: Visible text
+        comment: The text the reader sees, with a hover/tap marker after it.
+      annotation_content:
+        type: text
+        label: Annotation content
+        comment: The hidden note revealed when the marker is clicked.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

Adds a custom **Annotation** snippet to the CloudCannon **Add snippet** menu, alongside the existing button snippets. Editors can now insert an mkdocs-material annotation from the GUI by filling in two fields: the visible text and the revealed note. The snippet emits the standard `{ .annotate }` Markdown structure.

Verified locally with `mkdocs serve` and a real browser: the snippet output renders as a working annotation (marker opens a tooltip showing the note).

Known limitation: this covers the common single-annotation case. It can't inject a marker into prose already typed in the rich-text editor, and a block needing multiple markers still requires the source editor.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [ ] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [x] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [ ] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new annotation snippet enabling users to seamlessly create annotated text blocks within their editor. The snippet includes editor preview and picker functionality, configurable parameters for annotated text and annotation content, and customizable input fields with labels and descriptive comments to enhance the annotation workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ApolloAutomation/docs/pull/868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->