### PR TITLE
Remove broken mkdoc_annotation CloudCannon snippet (fixes Rich Text editor)

### DIFF
--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -208,36 +208,3 @@ _snippets:
         label: Button Icon
         comment: >
           Search available icons <a href="https://squidfunk.github.io/mkdocs-material/reference/icons-emojis/#search">here</a>. Remove the colons on each side when pasting.
-#brandon added this for annotations
-  mkdoc_annotation:
-    snippet: "[[annotated_text]] (1)\n{ .annotate }\n\n1.  [[annotation_content]]"
-    preview:
-      text:
-        - key: annotated_text
-        - 'Annotation'
-      subtext:
-        - key: annotation_content
-    picker_preview:
-      text: Annotation
-    params:
-      annotated_text:
-        parser: content
-        options:
-          editor_key: annotated_text
-          style:
-            trim_text: true
-      annotation_content:
-        parser: content
-        options:
-          editor_key: annotation_content
-          style:
-            trim_text: true
-    _inputs:
-      annotated_text:
-        type: text
-        label: Visible text
-        comment: The text the reader sees, with a hover/tap marker after it.
-      annotation_content:
-        type: text
-        label: Annotation content
-        comment: The hidden note revealed when the marker is clicked.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

Fixes the CloudCannon Rich Text editor, which was failing with **"Failed to process the current value. Please ensure that the value is valid markdown"** on every page.

Root cause: the `mkdoc_annotation` `_snippets` definition added in #868. Unlike the working button snippets (single-line inline templates), the annotation template spans multiple blocks (paragraph + `{ .annotate }` attribute + ordered list). CloudCannon builds a matcher from every snippet template and runs it against the whole page on load; it cannot compile this block-spanning template, so processing throws even on pages that contain no annotations.

No documentation page uses the annotation syntax (`{ .annotate }`), so removing the definition loses no content. This reverts `cloudcannon.config.yml` to the last known-good state (`9cd1310`), which the CloudCannon GUI was itself able to edit. Annotations can still be authored in CloudCannon's source mode.

Verification: edited config is byte-identical to `9cd1310` (confirmed with `git diff`) and parses as valid YAML. (`mkdocs serve` is not applicable here, this is a CloudCannon editor config, not site content.)

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [ ] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [x] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [ ] Changes previewed locally with `mkdocs serve`
  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [ ] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced button snippet with icon selection capability and helpful icon search reference.

* **Chores**
  * Removed annotation snippet configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ApolloAutomation/docs/pull/877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->