### PR TITLE
chore: sync dev with main

### DIFF
--- a/docs/homey/products/btn1/battery-sensors/wake-up-battery-sensor.md
+++ b/docs/homey/products/btn1/battery-sensors/wake-up-battery-sensor.md
@@ -1,0 +1,1 @@
+--8<-- "products/general/battery-sensors/wake-up-battery-sensor.md:5:"

--- a/docs/homey/products/general/battery-sensors/wake-up-battery-sensor.md
+++ b/docs/homey/products/general/battery-sensors/wake-up-battery-sensor.md
@@ -2,30 +2,4 @@
 title: Apollo Battery Devices - wake up battery device.
 description: How to wake up your Apollo device which is currently sleeping.
 ---
-###### Method 1
-
-Press the reset button and let go to restart the device<br><a href="https://wiki.apolloautomation.com/products/temp1b/troubleshooting/temp1b-boot-mode" target="_blank" rel="noreferrer nofollow noopener"><strong>TEMP-1B reset button</strong></a>
-
-![](/assets/temp-1-reset-button-lid-off.jpg)
-
-<br><a href="https://wiki.apolloautomation.com/products/plt1b/troubleshooting/plt1b-boot-mode/" target="_blank" rel="noreferrer nofollow noopener"><strong>PLT-1B reset button</strong></a>
-
-![](/assets/plt-boot-mode-pic-6-1.jpg)
-
-###### Method 2
-
-Quickly press and hold the boot button for 4-5 seconds
-
-<a href="https://wiki.apolloautomation.com/products/temp1b/troubleshooting/temp1b-boot-mode" target="_blank" rel="noopener"><strong>TEMP-1B boot button</strong></a>
-
-![](/assets/temp-1b-boot-button-lid-off.jpg)
-
-<a href="https://wiki.apolloautomation.com/products/plt1b/troubleshooting/plt1b-boot-mode/" target="_blank" rel="noreferrer nofollow noopener"><strong>PLT-1B boot button</strong></a>
-
-![](/assets/plt-boot-mode-pic-2.jpg)
-
-Your device is now "awake" but it will not stay awake on its own yet. Click the "prevent sleep" button on your device page in Home Assistant or directly on the device web server such as plt-1.local or its IP address.
-
-!!! success "Head to the awake helper wiki article"
-
-    If you need to keep your sensor awake for extended periods of time we suggest using our [OTA awake helper](https://wiki.apolloautomation.com/products/general/battery-sensors/awake-ha-helper/).
+--8<-- "products/general/battery-sensors/wake-up-battery-sensor.md:5:"

--- a/docs/products/btn1/battery-sensors/wake-up-battery-sensor.md
+++ b/docs/products/btn1/battery-sensors/wake-up-battery-sensor.md
@@ -1,0 +1,1 @@
+--8<-- "products/general/battery-sensors/wake-up-battery-sensor.md:5:"

--- a/docs/products/general/battery-sensors/wake-up-battery-sensor.md
+++ b/docs/products/general/battery-sensors/wake-up-battery-sensor.md
@@ -2,29 +2,71 @@
 title: Apollo Battery Devices - wake up battery device.
 description: How to wake up your Apollo device which is currently sleeping.
 ---
-###### Method 1
+There are two ways to wake a sleeping Apollo battery sensor: press the reset button, or hold the boot button. Select your device below for the button locations.
 
-Press the reset button and let go to restart the device<br><a href="https://wiki.apolloautomation.com/products/temp1b/troubleshooting/temp1b-boot-mode" target="_blank" rel="noreferrer nofollow noopener"><strong>TEMP-1B reset button</strong></a>
+=== "TEMP-1B"
 
-![](/assets/temp-1-reset-button-lid-off.jpg)
+    **Method 1: Reset button.** Press and release the reset button to restart the device.
 
-<br><a href="https://wiki.apolloautomation.com/products/plt1b/troubleshooting/plt1b-boot-mode/" target="_blank" rel="noreferrer nofollow noopener"><strong>PLT-1B reset button</strong></a>
+    ![](/assets/temp-1-reset-button-lid-off.jpg)
 
-![](/assets/plt-boot-mode-pic-6-1.jpg)
+    **Method 2: Boot button.** Quickly press and hold the boot button for 4-5 seconds.
 
-###### Method 2
+    ![](/assets/temp-1b-boot-button-lid-off.jpg)
 
-Quickly press and hold the boot button for 4-5 seconds
+    Button locations: [TEMP-1B boot mode](https://wiki.apolloautomation.com/products/temp1b/troubleshooting/temp1b-boot-mode/).
 
-<a href="https://wiki.apolloautomation.com/products/temp1b/troubleshooting/temp1b-boot-mode" target="_blank" rel="noopener"><strong>TEMP-1B boot button</strong></a>
+=== "PLT-1B"
 
-![](/assets/temp-1b-boot-button-lid-off.jpg)
+    **Method 1: Reset button.** Press and release the reset button to restart the device.
 
-<a href="https://wiki.apolloautomation.com/products/plt1b/troubleshooting/plt1b-boot-mode/" target="_blank" rel="noreferrer nofollow noopener"><strong>PLT-1B boot button</strong></a>
+    ![](/assets/plt-boot-mode-pic-6-1.jpg)
 
-![](/assets/plt-boot-mode-pic-2.jpg)
+    **Method 2: Boot button.** Quickly press and hold the boot button for 4-5 seconds.
 
-Your device is now "awake" but it will not stay awake on its own yet. Click the "prevent sleep" button on your device page in Home Assistant or directly on the device web server such as plt-1.local or its IP address.
+    ![](/assets/plt-boot-mode-pic-2.jpg)
+
+    Button locations: [PLT-1B boot mode](https://wiki.apolloautomation.com/products/plt1b/troubleshooting/plt1b-boot-mode/).
+
+=== "BTN-1"
+
+    **Method 1: Reset button.** Press and release the reset (left) button to restart the device.
+
+    **Method 2: Boot button.** Quickly press and hold the boot (right) button for 4-5 seconds.
+
+    ![](/assets/btn-1-reset-boot-buttons.png)
+
+    Button locations: [BTN-1 boot mode](https://wiki.apolloautomation.com/products/btn1/troubleshooting/btn1-boot-mode/).
+
+=== "H-1"
+
+    !!! note "Smart firmware only"
+
+        The H-1 only sleeps when running the [smart firmware](https://wiki.apolloautomation.com/products/h1/reflash/). These steps apply when it is running that firmware.
+
+    **Method 1: Reset button.** Press and release the reset button to restart the device.
+
+    **Method 2: Boot button.** Quickly press and hold the boot button for 4-5 seconds.
+
+    ![](/assets/screenshot-2024-11-01-015948.png)
+
+    Button locations: [H-1 boot mode](https://wiki.apolloautomation.com/products/h1/boot-mode/).
+
+=== "H-2"
+
+    !!! note "Smart firmware only"
+
+        The H-2 only sleeps when running the [smart firmware](https://wiki.apolloautomation.com/products/h2/troubleshooting/reflash/). These steps apply when it is running that firmware.
+
+    **Method 1: Reset button.** Press and release the reset (left) button to restart the device.
+
+    **Method 2: Boot button.** Quickly press and hold the boot (right) button for 4-5 seconds.
+
+    ![](/assets/h-2-reset-and-boot-buttons-labeled.png)
+
+    Button locations: [H-2 boot mode](https://wiki.apolloautomation.com/products/h2/troubleshooting/boot-mode/).
+
+Your device is now awake, but it will not stay awake on its own yet. Click the **Prevent Sleep** button on your device page in Home Assistant, or directly on the device web server such as plt-1.local or its IP address.
 
 !!! success "Head to the awake helper wiki article"
 

--- a/docs/products/h1/battery-sensors/wake-up-battery-sensor.md
+++ b/docs/products/h1/battery-sensors/wake-up-battery-sensor.md
@@ -1,0 +1,1 @@
+--8<-- "products/general/battery-sensors/wake-up-battery-sensor.md:5:"

--- a/docs/products/h1/boot-mode.md
+++ b/docs/products/h1/boot-mode.md
@@ -12,7 +12,7 @@ This will cover how to put the H-1 into boot mode. Sometimes, this is needed to 
 
 2\. Press and hold the boot button, while holding the boot button plug the H-1 back into your computer/power and then release the boot button
 
-3\. Continue with [uploading the firmware](https://wiki.apolloautomation.com/products/h1/code/)
+3\. Continue with [uploading the firmware](https://wiki.apolloautomation.com/products/h1/reflash/)
 
 ## **Boot and Reset Buttons**
 
@@ -20,4 +20,4 @@ This will cover how to put the H-1 into boot mode. Sometimes, this is needed to 
 
 2\. Press and hold the boot button, while holding it press and release the reset button, then release the boot button
 
-3\. Continue with [uploading the firmware](https://wiki.apolloautomation.com/products/h1/code/)
+3\. Continue with [uploading the firmware](https://wiki.apolloautomation.com/products/h1/reflash/)

--- a/docs/products/h1/getting-started.md
+++ b/docs/products/h1/getting-started.md
@@ -24,7 +24,7 @@ Once the ornament is awake, press the gold button (see image below) to play one 
 
 4\. Add to Home Assistant (Optional):
 
-For additional customization, you will need to flash the [smart H-1 firmware](https://wiki.apolloautomation.com/products/h1/code/) and then connect to Home Assistant following the [setup guide](https://wiki.apolloautomation.com/products/general/setup/getting-started/). Through Home Assistant, you can add new songs, change LED effects, and create custom automations.
+For additional customization, you will need to flash the [smart H-1 firmware](https://wiki.apolloautomation.com/products/h1/reflash/) and then connect to Home Assistant following the [setup guide](https://wiki.apolloautomation.com/products/general/setup/getting-started/). Through Home Assistant, you can add new songs, change LED effects, and create custom automations.
 
 5\. Enjoy Your Ornament:
 

--- a/docs/products/h1/reflash.md
+++ b/docs/products/h1/reflash.md
@@ -10,23 +10,23 @@ If your device has already been connected to Home Assistant previously please re
 2. Navigate to our installer page and click connect [\*\* Install Page \*\*](https://apolloautomation.github.io/H-1/)
 3. Select your Apollo device, it will show with a similar name to the one below, and click connect. If you aren't sure which device it is, you can unplug the sensor and see which disappears.
 
-[![ComSelection.png](https://apolloautomation.github.io/docs/products/mtr1/assets/comselection.png)](https://apolloautomation.github.io/docs/products/mtr1/assets/comselection.png)
+![](/assets/comselection.png)
 
 If no device shows, click cancel and then install the recommended driver that shows on the popup. If you have installed the driver, tried different cables, and it still won't work refer [here](https://wiki.apolloautomation.com/products/h1/boot-mode/) for putting the sensor in bootloader mode and then retry step 3.
 
 4\. Choose to install the new firmware
 
-[![](https://apolloautomation.github.io/docs/products/mtr1/assets/image-1698806750134.png)](https://apolloautomation.github.io/docs/products/mtr1/assets/image-1698806750134.png)
+![](/assets/image-1698806750134.png)
 
 5\. Wait for the installer to finish - if you see "ERROR Logger is not configured!" that is totally expected! The logger is disabled to make more room for other components on the microcontroller.
 
-[![](https://apolloautomation.github.io/docs/products/mtr1/assets/image-1698806082666.png)](https://apolloautomation.github.io/docs/products/mtr1/assets/image-1698806082666.png)
+![](/assets/image-1698806082666.png)
 
 6\. VERY IMPORTANT - you need to unplug your device and plug it back in to leave boot mode!
 
-1. After finishing, check for the Apollo hotspot and connect. This might not show if you previously had the MTR-1 connected to your wifi
+1. After finishing, check for the Apollo hotspot and connect. This might not show if you previously had the H-1 connected to your wifi
 2. Log into Home Assistant and go to the ESPHome app check to see if you can adopt the device.
 
 If you encounter the below error, please complete the [Putting H-1 In Boot Mode Document](https://wiki.apolloautomation.com/products/h1/boot-mode/) and go back to step 3.
 
-[![](https://apolloautomation.github.io/docs/products/mtr1/assets/image-1698806793309.png)](https://apolloautomation.github.io/docs/products/mtr1/assets/image-1698806793309.png)
+![](/assets/image-1698806793309.png)

--- a/docs/products/h2/battery-sensors/wake-up-battery-sensor.md
+++ b/docs/products/h2/battery-sensors/wake-up-battery-sensor.md
@@ -1,0 +1,1 @@
+--8<-- "products/general/battery-sensors/wake-up-battery-sensor.md:5:"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -496,6 +496,7 @@ nav:
             - General Tips: products/btn1/setup/general-tips.md
             - Sensor Definitions: products/btn1/setup/sensor-definitions.md
             - Prevent Sleep: products/btn1/additional-info/prevent-sleep.md
+            - How To Wake Up Your Sensor: products/btn1/battery-sensors/wake-up-battery-sensor.md
           - Examples:
             - Blueprint: products/btn1/examples/blueprint.md
           - Troubleshooting:
@@ -532,16 +533,20 @@ nav:
               - Introduction: products/h1/introduction.md
               - FAQ: products/h1/faq.md
               - Getting Started: products/h1/getting-started.md
+              - Additional Info:
+                - How To Wake Up Your Sensor: products/h1/battery-sensors/wake-up-battery-sensor.md
               - Reviews: products/h1/reviews.md
               - Examples:
                 - Holiday Songs: products/general/holiday-songs.md
               - Troubleshooting:
                 - H-1 Boot Mode: products/h1/boot-mode.md
-                - Factory Re-Flash H-1: products/h1/code.md
+                - Factory Re-Flash H-1: products/h1/reflash.md
           - H-2:
               - Introduction: products/h2/introduction.md
               - FAQ: products/h2/faq.md
               - Getting Started: products/h2/setup/getting-started.md
+              - Additional Info:
+                - How To Wake Up Your Sensor: products/h2/battery-sensors/wake-up-battery-sensor.md
               - Reviews: products/h2/h2-reviews.md
               - Examples:
                 - Holiday Songs: products/h2/examples/holiday-songs.md
@@ -833,6 +838,7 @@ nav:
             - General Tips: homey/products/btn1/setup/general-tips.md
             - Sensor Definitions: homey/products/btn1/setup/sensor-definitions.md
             - Prevent Sleep: homey/products/btn1/additional-info/prevent-sleep.md
+            - How To Wake Up Your Sensor: homey/products/btn1/battery-sensors/wake-up-battery-sensor.md
           - Addons:
             - BTN-1 Addon: homey/products/btn1/addons/btn1-addon.md
           - Examples:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

Routine `dev → main` sync so the live wiki rebuilds and publishes. Brings in the merged wake-up battery sensor restructure (#883): per-device content tabs covering TEMP-1B/PLT-1B/BTN-1/H-1/H-2, Homey general snippet wrapper, new device wrapper pages + nav, the H-1 `code → reflash` rename, and the H-1 flashing-page image fixes.

<!-- This is a publish sync PR (dev → main), so it targets `main` by design rather than `dev`. -->

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [ ] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [ ] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [x] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->
