### PR TITLE
Restore broken list/annotation formatting on automation pages

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/automations/motion-activated-light.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/motion-activated-light.md
@@ -20,34 +20,39 @@ This tutorial uses the Motion module and the LED & Buzzer module connected to th
 
 ESPHome Device Builder has a GUI for building <a href="https://esphome.io/automations/" target="_blank" rel="noreferrer nofollow noopener">automations</a>, so you can wire a trigger to an action without hand-writing YAML. The trigger is the *when*, the thing that makes it fire. The action is the *then do*, what happens when it fires.
 
-1. Open your starter kit device in ESPHome Device Builder and click **Edit**. If you need a refresher on the editor, see the [Device Builder Tour](../learning-the-basics/device-builder-tour.md#editor).
-2. In the editor's left pane, expand the **Automations** dropdown and click **Add Automation**.
-3. Set up the trigger:
+1.  Open your starter kit device in ESPHome Device Builder and click **Edit**. If you need a refresher on the editor, see the [Device Builder Tour](../learning-the-basics/device-builder-tour.md#editor).
+2.  In the editor's left pane, expand the **Automations** dropdown and click **Add Automation**.
 
-   <div markdown class="annotate">
+    ![](../../../assets/esphome-device-builder-add-automation.gif)
 
-                - **What should this automation react to?** → **A configured component**
-                - **Which configured component?** → **Motion Module (binary_sensor.gpio)**
-                - **Which trigger?** → **Binary Sensor → On Click** (1)
+3.  Set up the trigger:
 
-                </div> ![](../../../assets/esphome-device-builder-add-automation.gif)
-   1. **On Click** fires the moment the sensor detects motion. The dropdown also offers **On Release** (the moment motion stops) and **On State** for other occupancy behaviors. You'll use **On Release** in the optional step below to turn the light back off.
-4. Click **Continue**. You land on the **Binary Sensor → On Click** editor with the **Target** already set to your Motion module.
+    <div class="annotate" markdown>
 
-![](../../../assets/esphome-device-builder-motion-sensor-trigger.gif)
+    - **What should this automation react to?** → **A configured component**
+    - **Which configured component?** → **Motion Module (binary_sensor.gpio)**
+    - **Which trigger?** → **Binary Sensor → On Click** (1)
 
-1. Set up the action:
+    </div>
 
-   <div markdown class="annotate">
+    1.  **On Click** fires the moment the sensor detects motion. The dropdown also offers **On Release** (the moment motion stops) and **On State** for other occupancy behaviors. You'll use **On Release** in the optional step below to turn the light back off.
 
-                - Under **Actions**, click **+ Add action**.
-                - In the **Add action** dialog, stay on the **By target** tab and choose **Light → Turn On** under the RGB LED group.
-                - On the new action, click the **ID** dropdown and select **RGB LEDs**. (1)
+    ![](../../../assets/esphome-device-builder-motion-sensor-trigger.gif)
 
-                </div>
-   1. The **ID** dropdown only needs changing if your device also has an **Onboard RGB LED** component configured. If **RGB LEDs** is the only light, it's already selected.
+4.  Click **Continue**. You land on the **Binary Sensor → On Click** editor with the **Target** already set to your Motion module.
+5.  Set up the action:
 
-![](../../../assets/esphome-device-builder-light-turn-on-action.gif)
+    <div class="annotate" markdown>
+
+    - Under **Actions**, click **+ Add action**.
+    - In the **Add action** dialog, stay on the **By target** tab and choose **Light → Turn On** under the RGB LED group.
+    - On the new action, click the **ID** dropdown and select **RGB LEDs**. (1)
+
+    </div>
+
+    1.  The **ID** dropdown only needs changing if your device also has an **Onboard RGB LED** component configured. If **RGB LEDs** is the only light, it's already selected.
+
+    ![](../../../assets/esphome-device-builder-light-turn-on-action.gif)
 
 ??? note "What the GUI built in YAML"
 
@@ -89,15 +94,15 @@ With the device back online, wave your hand in front of the PIR sensor. The RGB 
 
 Right now the light turns on with motion but never turns off. Add a second trigger to the same Motion module so the light switches off once motion clears.
 
-1. Add another automation, this time choosing **Binary Sensor → On Release** as the trigger for the Motion module.
+1.  Add another automation, this time choosing **Binary Sensor → On Release** as the trigger for the Motion module.
 
-![](../../../assets/esphome-device-builder-motion-sensor-on-release.gif)
+    ![](../../../assets/esphome-device-builder-motion-sensor-on-release.gif)
 
-1. Give it a **Light → Turn Off** action targeting **RGB LEDs**.
+2.  Give it a **Light → Turn Off** action targeting **RGB LEDs**.
 
-![](../../../assets/esphome-device-builder-light-turn-off-action.gif)
+    ![](../../../assets/esphome-device-builder-light-turn-off-action.gif)
 
-1. **Save** and **Install** again.
+3.  **Save** and **Install** again.
 
 ??? note "What the GUI built in YAML"
 

--- a/docs/products/ESPHome-Starter-Kit/automations/play-a-tune.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/play-a-tune.md
@@ -30,43 +30,45 @@ When you added the LED & Buzzer module, Device Builder created an `rtttl` compon
 
 ESPHome Device Builder has a GUI for building <a href="https://esphome.io/automations/" target="_blank" rel="noreferrer nofollow noopener">automations</a>, so you can wire a trigger to an action without hand-writing YAML. The trigger is the *when*, the thing that makes it fire. The action is the *then do*, what happens when it fires.
 
-1. Open your starter kit device in ESPHome Device Builder and click **Edit**. If you need a refresher on the editor, see the [Device Builder Tour](../learning-the-basics/device-builder-tour.md#editor).
-2. In the editor's left pane, expand the **Automations** dropdown and click **Add Automation**.
+1.  Open your starter kit device in ESPHome Device Builder and click **Edit**. If you need a refresher on the editor, see the [Device Builder Tour](../learning-the-basics/device-builder-tour.md#editor).
+2.  In the editor's left pane, expand the **Automations** dropdown and click **Add Automation**.
 
-   ![](../../../assets/esphome-device-builder-add-automation.gif)
+    ![](../../../assets/esphome-device-builder-add-automation.gif)
 
-3. Set up the trigger:
+3.  Set up the trigger:
 
-   <div markdown class="annotate">
+    <div class="annotate" markdown>
 
-             - **What should this automation react to?** → **A configured component**
-             - **Which configured component?** → **Button Module (binary_sensor.gpio)**
-             - **Which trigger?** → **Binary Sensor → On Click** (1)
+    - **What should this automation react to?** → **A configured component**
+    - **Which configured component?** → **Button Module (binary_sensor.gpio)**
+    - **Which trigger?** → **Binary Sensor → On Click** (1)
 
-             </div>
-   1. The trigger dropdown also offers **On Double Click**, **On Multi Click**, **On Press**, **On Release**, **On State**, and **On State Change** for other button gestures. Swap any of these in once you're comfortable with the On Click flow.
+    </div>
 
-   ![](../../../assets/esphome-device-builder-add-button-trigger-automation.gif)
+    1.  The trigger dropdown also offers **On Double Click**, **On Multi Click**, **On Press**, **On Release**, **On State**, and **On State Change** for other button gestures. Swap any of these in once you're comfortable with the On Click flow.
 
-4. Click **Continue**. You land on the **Binary Sensor → On Click** editor with the **Target** already set to your Button module.
-5. Set up the action:
+    ![](../../../assets/esphome-device-builder-add-button-trigger-automation.gif)
 
-   <div markdown class="annotate">
+4.  Click **Continue**. You land on the **Binary Sensor → On Click** editor with the **Target** already set to your Button module.
+5.  Set up the action:
 
-             - Under **Actions**, click **+ Add action**.
-             - In the **Add action** dialog, click **By type** then search Rtttl and choose **Rtttl → Play**.
-             - In the **Rtttl** (tune) field, paste an RTTTL string. Copy the one below to get started, or use one of the [examples below](#find-more-tunes). (1)
+    <div class="annotate" markdown>
 
-             </div>
-   1. If your device has more than one `rtttl` component, set the **ID** to **rtttl\_buzzer**. With a single buzzer it's already selected.
+    - Under **Actions**, click **+ Add action**.
+    - In the **Add action** dialog, click **By type** then search Rtttl and choose **Rtttl → Play**.
+    - In the **Rtttl** (tune) field, paste an RTTTL string. Copy the one below to get started, or use one of the [examples below](#find-more-tunes). (1)
 
-   Copy this tune and paste it into the **Rtttl** field:
+    </div>
 
-   ```text
-   The Simpsons:d=4,o=5,b=160:c.,e,f#,8a,g.,e,c,8a4,8f#4,8f#4,8f#4,2g4,8p,8p,8f#4,8f#4,8f#4,8g4,a4.,8c,16p,8c,16p,8c,2c
-   ```
+    1.  If your device has more than one `rtttl` component, set the **ID** to **rtttl_buzzer**. With a single buzzer it's already selected.
 
-![](../../../assets/esphome-device-builder-configure-rtttl-play-action.gif)
+    Copy this tune and paste it into the **Rtttl** field:
+
+    ```text
+    The Simpsons:d=4,o=5,b=160:c.,e,f#,8a,g.,e,c,8a4,8f#4,8f#4,8f#4,2g4,8p,8p,8f#4,8f#4,8f#4,8g4,a4.,8c,16p,8c,16p,8c,2c
+    ```
+
+    ![](../../../assets/esphome-device-builder-configure-rtttl-play-action.gif)
 
 ??? note "What the GUI built in YAML"
 
@@ -136,4 +138,4 @@ Want more? <a href="https://picaxe.com/rtttl-ringtones-for-tune-command/" title=
 
     Same trigger-then-action pattern, new action. Swap the trigger (motion, a temperature threshold, a schedule) or the tune, and you have a new automation.
 
-[Check out these Holiday themed buzzer examples too! :material-music-note:](https://wiki.apolloautomation.com/products/general/holiday-songs/){    .md-button .md-button--primary }
+[Check out these Holiday themed buzzer examples too! :material-music-note:](https://wiki.apolloautomation.com/products/general/holiday-songs/){ .md-button .md-button--primary }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

Fixes broken indentation on two ESPHome Starter Kit automation tutorials that the CloudCannon web editor flattened in recent edits:

- [Play a Tune with the Button](https://wiki.apolloautomation.com/products/ESPHome-Starter-Kit/automations/play-a-tune/)
- [Turn On a Light with Motion](https://wiki.apolloautomation.com/products/ESPHome-Starter-Kit/automations/motion-activated-light/)

On both pages CloudCannon's edits demoted the ordered list, flattened the `<div class="annotate" markdown>` blocks into single-line runs separated by literal hyphens, over-indented the inner bullets so they rendered as code blocks, and broke the parent list so the step numbering restarted mid-page (Play a Tune showed two `1.`'s; Motion-Activated Light's optional section showed three).

This PR restores:

- Four-space list indentation with `1.  ` so the steps stay one continuous list 1 through 5 under **Build the automation**.
- `<div class="annotate" markdown>` attribute order so the bullets and `(+)` annotation footnotes render properly.
- GIFs scoped inside the right step (trigger demo inside step 3, action demo inside step 5).
- Motion-Activated Light's **Optional: turn the light off when motion stops** section renumbered 1, 2, 3.

Keeps the CloudCannon content additions (The Simpsons RTTTL tune, the **By type** Add action hint, and the new trigger/action demo GIFs) intact, only the markdown structure changed.

Previewed locally with `mkdocs serve` and verified both pages render with continuous numbered lists, proper annotation popups, and inline GIFs.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [x] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [x] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [x] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced ESPHome Starter Kit automation tutorials with improved step-by-step formatting and repositioned visual guides. The motion-activated light and button-triggered audio playback tutorials now feature explicitly numbered instructions, streamlined content organization, and optimized guide placement to facilitate easier understanding and more efficient implementation of automation workflows for end-users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ApolloAutomation/docs/pull/892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->