### PR TITLE
docs(mtr1): rebuild Sensor Definitions with tabbed layout and update intervals

### DIFF
--- a/docs/products/mtr1/setup/sensor-definitions.md
+++ b/docs/products/mtr1/setup/sensor-definitions.md
@@ -78,7 +78,7 @@ Once added to Home Assistant you can configure different settings for your MTR-1
     |--------|:--------------:|---------------|
     | **Apollo Firmware Version** | on boot | The Apollo firmware build installed on the device (for example, `26.3.2.1`). |
     | **ESPHome Version** | on boot | The ESPHome version the firmware was compiled with. |
-    | **Firmware** | — | Shows whether a firmware update is available and lets you update from inside Home Assistant. |
+    | **Firmware Update** | — | Shows whether a firmware update is available and lets you update from inside Home Assistant. Separate from the **Apollo Firmware Version** and **ESPHome Version** sensors above. |
     | **IP Address** | on connect | The device's IP address on your network. |
     | **Online** | on change | Connection status of the device to Home Assistant. |
     | **RSSI** | 60s | Wi-Fi signal strength in dBm. Values closer to 0 are stronger; a weak signal can affect reliability. |

--- a/docs/products/mtr1/setup/sensor-definitions.md
+++ b/docs/products/mtr1/setup/sensor-definitions.md
@@ -1,279 +1,90 @@
 ---
-title: MTR-1 Sensor Definitons
+title: MTR-1 Sensor Definitions
 description: These are all of the entities exposed by the MTR-1 to automate on!
 ---
 # Sensor Definitions
 
-???+ info "Controls"
-
-    **RGB Light**
-
-    * One RGB Neopixel LED. Click on the light bulb or color wheel to change the color. Click on the toggle to turn on or off.
-
-    **Calibrate SCD40 to 420ppm**
-
-    * A control option to <a href="https://wiki.apolloautomation.com/products/general/calibrating-and-updating/co2-calibration/" target="_blank" rel="noopener">calibrate the SCD40 CO₂ sensor</a> to <a href="https://climate.nasa.gov/vital-signs/carbon-dioxide/?intent=121" target="_blank" rel="noopener">outdoor baseline levels.</a>
-
-???+ info "Sensors"
-
-    **CO<sub>2</sub>**
-
-    * True CO<sub>2</sub> reading from the SCD40. This will be Unknown if you do not have the CO<sub>2</sub> module. SDC40 can be calibrated <a href="https://wiki.apolloautomation.com/products/general/calibrating-and-updating/co2-calibration/" title="CO<sub>2</sub> Calibration" target="_blank" rel="noopener">following this guide</a>.
-
-    **ESP Temperature**
-
-    * This is the temperature of the internal microcontroller. Think of it like your measured CPU temp on your PC.
-
-    **DPS310 Pressure**
-
-    * Measures the air pressure in the environment. Note: A small subset of devices do not include a DPS310 sensor. If this sensor is unknown, your device may be one of these units.
-
-    **DPS310 Temperature**
-
-    * Measures the ambient air temperature using the DPS310 sensor. Note: A small subset of devices do not include a DPS310 sensor. If this sensor is unknown, your device may be one of these units.
-
-    **LTR390 Light**
-
-    * Light level measured in lux by LTR390.
-
-    **LTR390 UV Index**
-
-    * UV index measured by LTR390.
-
-    **Moving Target Count**
-
-    * Count of all moving targets. (max 3)
-
-    **Presence Target Count**
-
-    * Count of all presence targets. (max 3)
-
-    **Still Target Count**
-
-    * Count of all still targets. (max 3)
-
-    **Target-1 Angle**
-
-    * Angle of target in `degrees (°)` relative to the `ld2450` sensor.
-
-    **Target-1 Direction**
-
-    * Direction of the target relative to the `ld2450` sensor. Possible values are: `Stationary`, `Moving away`, `Approaching`, `NA`.
-
-    **Target-1 Distance**
-
-    * Distance in `millimeter (mm)` of the target from the `ld2450` sensor along the X-axis (negative for left side of the sensor, positive for right side of the sensor). The `ld2450` module can detect targets from -3000 to 3000 mm in `X` direction.
-
-    **Target-1 Resolution**
-
-    * The `ld2450` target detection range resolution in `millimeter (mm)`.
-
-    **Target-1 Speed**
-
-    * Speed of the moving target in `mm/s`.
-
-    **Target-1 X**
-
-    * Distance in `millimeter (mm)` of the target from the `ld2450` sensor along the X-axis (negative for left side of the sensor, positive for right side of the sensor). The `ld2450` module can detect targets from -3000 to 3000 mm in `X` direction.
-
-    **Target-1 Y**
-
-    * Distance in `millimeter (mm)` of the target from the `ld2450` sensor in the Y direction (near/far). The `ld2450` module can detect targets from 0 to 6000 mm in `Y` direction.
-
-    **Target-2 Angle**
-
-    * Angle of target in `degrees (°)` relative to the `ld2450` sensor.
-
-    **Target-2 Direction**
-
-    * Direction of the target relative to the `ld2450` sensor. Possible values are: `Stationary`, `Moving away`, `Approaching`, `NA`.
-
-    **Target-2 Distance**
-
-    * Distance in `millimeter (mm)` of the target from the `ld2450` sensor along the X-axis (negative for left side of the sensor, positive for right side of the sensor). The `ld2450` module can detect targets from -3000 to 3000 mm in `X` direction.
-
-    **Target-2 Resolution**
-
-    * The `ld2450` target detection range resolution in `millimeter (mm)`.
-
-    **Target-2 Speed**
-
-    * Speed of the moving target in `mm/s`.
-
-    **Target-2 X**
-
-    * Distance in `millimeter (mm)` of the target from the `ld2450` sensor along the X-axis (negative for left side of the sensor, positive for right side of the sensor). The `ld2450` module can detect targets from -3000 to 3000 mm in `X` direction.
-
-    **Target-2 Y**
-
-    * Distance in `millimeter (mm)` of the target from the `ld2450` sensor in the Y direction (near/far). The `ld2450` module can detect targets from 0 to 6000 mm in `Y` direction.
-
-    **Target-3 Angle**
-
-    * Angle of target in `degrees (°)` relative to the `ld2450` sensor.
-
-    **Target-3 Direction**
-
-    * Direction of the target relative to the `ld2450` sensor. Possible values are: `Stationary`, `Moving away`, `Approaching`, `NA`.
-
-    **Target-3 Distance**
-
-    * Distance in `millimeter (mm)` of the target from the `ld2450` sensor along the X-axis (negative for left side of the sensor, positive for right side of the sensor). The `ld2450` module can detect targets from -3000 to 3000 mm in `X` direction.
-
-    **Target-3 Resolution**
-
-    * The `ld2450` target detection range resolution in `millimeter (mm)`.
-
-    **Target-3 Speed**
-
-    * Speed of the moving target in `mm/s`.
-
-    **Target-3 X**
-
-    * Distance in `millimeter (mm)` of the target from the `ld2450` sensor along the X-axis (negative for left side of the sensor, positive for right side of the sensor). The `ld2450` module can detect targets from -3000 to 3000 mm in `X` direction.
-
-    **Target-3 Y**
-
-    * Distance in `millimeter (mm)` of the target from the `ld2450` sensor in the Y direction (near/far). The `ld2450` module can detect targets from 0 to 6000 mm in `Y` direction.
-
-    **Zone-1 All Target Count**
-
-    * Total targets detected in the zone, whether they are stationary or in motion.
-
-    **Zone-1 Moving Target Count**
-
-    * Count of moving targets in the zone.
-
-    **Zone-1 Still Target Count**
-
-    * Count of stationary targets in the zone.
-
-    **Zone-2 All Target Count**
-
-    * Total targets detected in the zone, whether they are stationary or in motion.
-
-    **Zone-2 Moving Target Count**
-
-    * Count of moving targets in the zone.
-
-    **Zone-2 Still Target Count**
-
-    * Count of stationary targets in the zone.
-
-    **Zone-3 All Target Count**
-
-    * Total targets detected in the zone, whether they are stationary or in motion.
-
-    **Zone-3 Moving Target Count**
-
-    * Count of moving targets in the zone.
-
-    **Zone-3 Still Target Count**
-
-    * Count of stationary targets in the zone.
-
-???+ info "Configuration"
-
-    **DPS310 Temperature Offset**
-
-    * Offset value of the DPS310 Temperature. Note: A small subset of devices do not include a DPS310 sensor. If this option is unknown, your device may be one of these units.
-
-    **ESP Reboot**
-
-    * Performs a restart of the sensor.
-
-    **Firmware**
-
-    * Shows available updates and allows updating inside of Home Assistant.
-
-    **LD2450 Bluetooth**
-
-    * Toggles the Bluetooth of the LD2450 to directly connect with a phone to the HLK Radartool App.
-
-    **Multi Target Tracking**
-
-    * Turn on/off the Multi Target Tracking option. The initial state set based on the corresponding setting as read from LD2450 module at boot.
-
-    **Timeout**
-
-    * The duration, in seconds, for which the [presence states](https://esphome.io/components/sensor/ld2450.html#ld2450-binary-sensors) will persist even after the detection is cleared. Default is `5` seconds.
-
-    **Zone Type**
-
-    * Control the zone detection modes. It can be set to `Disabled`, `Detection` or `Filter`. Selecting the `Disabled` option will disable zone area detection. `Detection` mode is used to detect only targets in the specified area, while `Filter` mode can be used to exclude an area from detection.
-
-    **Zone-1 X1**
-
-    * Start X coordinate in `millimeter (mm)` of the zone from the `ld2450` sensor along the X-axis (negative for left side (-3000) of the sensor, positive for right side (3000) of the sensor).
-
-    **Zone-1 X2**
-
-    * End X coordinate in `millimeter (mm)` of the zone from the `ld2450` sensor along the X-axis (negative for left side (-3000) of the sensor, positive for right side (3000) of the sensor).
-
-    **Zone-1 Y1**
-
-    * Start Y coordinate in `millimeter (mm)` of the zone from the `ld2450` sensor along the Y-axis, values range from 0 to 6000.
-
-    **Zone-1 Y2**
-
-    * Start Y coordinate in `millimeter (mm)` of the zone from the `ld2450` sensor along the Y-axis, values range from 0 to 6000.
-
-    **Zone-2 X1**
-
-    * Start X coordinate in `millimeter (mm)` of the zone from the `ld2450` sensor along the X-axis (negative for left side (-3000) of the sensor, positive for right side (3000) of the sensor).
-
-    **Zone-2 X2**
-
-    * End X coordinate in `millimeter (mm)` of the zone from the `ld2450` sensor along the X-axis (negative for left side (-3000) of the sensor, positive for right side (3000) of the sensor).
-
-    **Zone-2 Y1**
-
-    * Start Y coordinate in `millimeter (mm)` of the zone from the `ld2450` sensor along the Y-axis, values range from 0 to 6000.
-
-    **Zone-2 Y2**
-
-    * Start Y coordinate in `millimeter (mm)` of the zone from the `ld2450` sensor along the Y-axis, values range from 0 to 6000.
-
-    **Zone-3 X1**
-
-    * Start X coordinate in `millimeter (mm)` of the zone from the `ld2450` sensor along the X-axis (negative for left side (-3000) of the sensor, positive for right side (3000) of the sensor).
-
-    **Zone-3 X2**
-
-    * End X coordinate in `millimeter (mm)` of the zone from the `ld2450` sensor along the X-axis (negative for left side (-3000) of the sensor, positive for right side (3000) of the sensor).
-
-    **Zone-3 Y1**
-
-    * Start Y coordinate in `millimeter (mm)` of the zone from the `ld2450` sensor along the Y-axis, values range from 0 to 6000.
-
-    **Zone-3 Y2**
-
-    * Start Y coordinate in `millimeter (mm)` of the zone from the `ld2450` sensor along the Y-axis, values range from 0 to 6000.
-
-??? info "Diagnostic"
-
-    **ESP Temperature**
-
-    * Displays the current temperature of the ESP32 chip.
-
-    **LD2450 BT MAC**
-
-    * Bluetooth MAC Address of the LD2450 mmWave sensor.
-
-    **LD2450 Firmware**
-
-    * Firmware version installed on the LD2450. Defaults to 2.04.23101915
-
-    **Online**
-
-    * Shows the connection status.
-
-    **Uptime**
-
-    * Shows the time since last reboot.
-
-    **RSSI**
-
-    * Displays the Wi-Fi signal strength.
-
-[Join our Discord if you need more help! :simple-discord:](https://link.apolloautomation.com/discord){                      .md-button }
+Once added to Home Assistant you can configure different settings for your MTR-1. Use the tabs below to see what each entity does, grouped the same way Home Assistant displays them.
+
+!!! note "How often readings update"
+
+    The **Default Update** column is how often each entity refreshes. Radar entities update in real time as targets move. The **LTR390 Light** and **LTR390 UV Index** sensors use the interval set by the **LTR390 Update Interval** number (60s by default).
+
+=== "Controls"
+
+    | Control | What it does |
+    |---------|--------------|
+    | **RGB Light** | One RGB Neopixel LED. Click the light bulb or color wheel to change the color. Use the toggle to turn it on or off. |
+    | **Calibrate SCD40 To 420ppm** | Forces a fresh-air calibration of the SCD40 CO₂ sensor to the <a href="https://wiki.apolloautomation.com/products/general/calibrating-and-updating/co2-calibration/" target="_blank" rel="noopener">outdoor baseline</a> (about <a href="https://climate.nasa.gov/vital-signs/carbon-dioxide/?intent=121" target="_blank" rel="noopener">420 ppm</a>). Run it outdoors or next to an open window. |
+
+=== "Sensors"
+
+    #### Air quality &amp; light
+
+    | Sensor | Default Update | Details |
+    |--------|:--------------:|---------|
+    | **CO2** | 60s | True NDIR reading from the SCD40. Shows *Unknown* if you do not have the CO₂ module. You can <a href="https://wiki.apolloautomation.com/products/general/calibrating-and-updating/co2-calibration/" target="_blank" rel="noopener">re-calibrate it to the outdoor baseline</a>. |
+    | **DPS310 Pressure** | 30s | Barometric air pressure. A small subset of devices do not include a DPS310 sensor. If this reads *Unknown*, your device may be one of these units. |
+    | **DPS310 Temperature** | 30s | Ambient air temperature from the DPS310. A small subset of devices do not include a DPS310 sensor. |
+    | **LTR390 Light** | 60s* | Ambient light level in lux. *Polls at the **LTR390 Update Interval** (60s by default). |
+    | **LTR390 UV Index** | 60s* | UV index measured by the LTR390. *Polls at the **LTR390 Update Interval**. |
+    | **SCD40 Temperature** | 60s | Temperature from the SCD40. Disabled by default. Adjusted by the **SCD40 Temperature Offset**. |
+    | **SCD40 Humidity** | 60s | Humidity from the SCD40. Disabled by default. Adjusted by the **SCD40 Humidity Offset**. |
+
+    #### Radar (LD2450 mmWave)
+
+    | Sensor | Default Update | Details |
+    |--------|:--------------:|---------|
+    | **LD2450 Presence** | real-time | Whether the radar currently detects any target. Great for occupancy automations. |
+    | **LD2450 Moving Target** | real-time | Whether a moving target is detected. |
+    | **LD2450 Still Target** | real-time | Whether a stationary target is detected. |
+    | **Presence Target Count** | real-time | Count of all presence targets (max 3). |
+    | **Moving Target Count** | real-time | Count of all moving targets (max 3). |
+    | **Still Target Count** | real-time | Count of all still targets (max 3). |
+    | **Target-1 / Target-2 / Target-3 X** | real-time | Distance in mm of the target from the sensor along the X-axis (negative = left, positive = right, range -3000 to 3000). |
+    | **Target-1 / Target-2 / Target-3 Y** | real-time | Distance in mm of the target from the sensor in the Y direction (near/far, range 0 to 6000). |
+    | **Target-1 / Target-2 / Target-3 Speed** | real-time | Speed of the moving target in mm/s. |
+    | **Target-1 / Target-2 / Target-3 Angle** | real-time | Angle of the target in degrees relative to the sensor. |
+    | **Target-1 / Target-2 / Target-3 Distance** | real-time | Straight-line distance of the target from the sensor. |
+    | **Target-1 / Target-2 / Target-3 Resolution** | real-time | Target detection range resolution in mm. |
+    | **Target-1 / Target-2 / Target-3 Direction** | real-time | Direction of the target: `Stationary`, `Moving away`, `Approaching`, or `NA`. |
+    | **Zone-1 / Zone-2 / Zone-3 All Target Count** | real-time | Total targets in the zone, stationary or moving. |
+    | **Zone-1 / Zone-2 / Zone-3 Moving Target Count** | real-time | Count of moving targets in the zone. |
+    | **Zone-1 / Zone-2 / Zone-3 Still Target Count** | real-time | Count of stationary targets in the zone. |
+
+=== "Configuration"
+
+    | Setting | Default | What it does |
+    |---------|:-------:|--------------|
+    | **ESP Reboot** | — | Restarts the device. Helpful for troubleshooting or refreshing the connection. |
+    | **Multi Target Tracking** | from module | Turns multi-target tracking on or off. Initial state is read from the LD2450 at boot. |
+    | **Timeout** | 5 s | How long presence stays detected after the target is lost. See the <a href="https://esphome.io/components/sensor/ld2450.html#ld2450-binary-sensors" target="_blank" rel="noopener">ESPHome LD2450 docs</a>. |
+    | **Zone Type** | Disabled | Zone detection mode: `Disabled`, `Detection` (only detect targets inside the zone), or `Filter` (exclude the zone from detection). |
+    | **Zone-1 / Zone-2 / Zone-3 X1, X2** | — | Start and end X coordinates of the zone in mm (-3000 left to 3000 right). |
+    | **Zone-1 / Zone-2 / Zone-3 Y1, Y2** | — | Start and end Y coordinates of the zone in mm (0 to 6000). |
+    | **DPS310 Pressure Offset** | 0.0 hPa | Calibration offset for the DPS310 pressure reading. Disabled by default. |
+    | **DPS310 Temperature Offset** | — | Calibration offset for the DPS310 temperature reading. |
+    | **SCD40 Temperature Offset** | — | Calibration offset for the SCD40 temperature reading. Disabled by default. |
+    | **SCD40 Humidity Offset** | — | Calibration offset for the SCD40 humidity reading. Disabled by default. |
+    | **LTR390 Update Interval** | 60 s | How often the LTR390 light and UV sensors poll (1 to 300 seconds). |
+    | **LD2450 Bluetooth** | — | Toggles the LD2450's Bluetooth so you can connect with the HLK Radartool phone app. |
+    | **Baud rate** | from module | Serial baud rate for the LD2450 module. |
+    | **Factory Reset ESP** | — | Erases settings and returns the device to factory firmware defaults. Disabled by default. |
+    | **Factory Reset LD2450** | — | Resets the LD2450 radar module to its factory settings. |
+
+=== "Diagnostic"
+
+    | Entity | Default Update | What it shows |
+    |--------|:--------------:|---------------|
+    | **Apollo Firmware Version** | on boot | The Apollo firmware build installed on the device (for example, `26.3.2.1`). |
+    | **ESPHome Version** | on boot | The ESPHome version the firmware was compiled with. |
+    | **Firmware** | — | Shows whether a firmware update is available and lets you update from inside Home Assistant. |
+    | **IP Address** | on connect | The device's IP address on your network. |
+    | **Online** | on change | Connection status of the device to Home Assistant. |
+    | **RSSI** | 60s | Wi-Fi signal strength in dBm. Values closer to 0 are stronger; a weak signal can affect reliability. |
+    | **ESP Temperature** | 60s | Internal temperature of the ESP32 chip. Runs warmer than the room because of the processor and Wi-Fi radio. |
+    | **Uptime** | 60s | How long the device has been running since its last reboot. |
+    | **LD2450 Firmware** | on boot | Firmware version installed on the LD2450 radar module. |
+    | **LD2450 BT MAC** | on boot | Bluetooth MAC address of the LD2450 radar module. |
+
+[Join our Discord if you need more help! :simple-discord:](https://link.apolloautomation.com/discord){ .md-button }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

Rebuilds the **MTR-1 Sensor Definitions** page to match the new AIR-1 format (#900):

- Converts the stacked collapsible admonitions to a single **Controls / Sensors / Configuration / Diagnostic** content-tab strip backed by tables.
- Splits Sensors into **Air quality & light** and **Radar (LD2450 mmWave)** subsections.
- Adds a **Default Update** column sourced from firmware (`Core.yaml`, v26.3.2.1). Radar entities are real-time; LTR390 light/UV poll at the configurable **LTR390 Update Interval**.
- Documents the new firmware-version entities (**Apollo Firmware Version**, **ESPHome Version**, **IP Address**) and the SCD40/DPS310 offsets and LTR390 Update Interval that were missing.
- Fixes the title typo ("Definitons" → "Definitions").

Frontmatter stays 4 lines so the Homey mirror's `--8<--` snippet keeps inheriting this page.

## Types of changes

- [ ] Typo / wording fix
- [x] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:

  - [x] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [ ] If new pages were added, nav was updated in `mkdocs.yml`
