### PR TITLE
docs(btn1): rebuild Sensor Definitions with tabbed layout and update intervals

### DIFF
--- a/docs/products/btn1/setup/sensor-definitions.md
+++ b/docs/products/btn1/setup/sensor-definitions.md
@@ -4,88 +4,58 @@ description: These are all of the entities exposed by the BTN-1 to automate on!
 ---
 # Sensor Definitions
 
-This serves as a list of all sensor definitions to help understand what each entity does for your new BTN-1!
+Once added to Home Assistant you can configure different settings for your BTN-1. Use the tabs below to see what each entity does, grouped the same way Home Assistant displays them.
 
-???+ info "Controls"
+!!! note "How often readings update"
 
-    **BTN 1 Light**
+    The BTN-1 is a battery-powered device that deep-sleeps by default. The **Default Update** column is how often each entity refreshes while the BTN-1 is awake. With **Prevent Sleep** off, the BTN-1 wakes for about 90 seconds (on a button press or after the **Sleep Duration**), reports its values, then deep-sleeps again. While asleep it does not respond to Home Assistant. Turn **Prevent Sleep** on to keep it awake and reporting continuously, which is required for OTA updates.
 
-    * Controls the light in front of the first button. Defaults to off.
+=== "Controls"
 
-    **BTN 2 Light**
+    | Control | What it does |
+    |---------|--------------|
+    | **BTN 1 Light** | RGB light behind the first button. Click the light bulb or color wheel to change the color, or use the toggle to turn it on or off. Defaults to off. |
+    | **BTN 2 Light** | RGB light behind the second button. Click the light bulb or color wheel to change the color, or use the toggle to turn it on or off. Defaults to off. |
+    | **BTN 3 Light** | RGB light behind the third button. Click the light bulb or color wheel to change the color, or use the toggle to turn it on or off. Defaults to off. |
+    | **BTN 4 Light** | RGB light behind the fourth button. Click the light bulb or color wheel to change the color, or use the toggle to turn it on or off. Defaults to off. |
 
-    * Controls the light in front of the second button. Defaults to off.
+=== "Sensors"
 
-    **BTN 3 Light**
+    | Sensor | Default Update | Details |
+    |--------|:--------------:|---------|
+    | **Battery level** | per wake cycle | Remaining battery charge as a percentage, from 0 to 100%. Read from the MAX17048 fuel gauge. |
+    | **Battery voltage** | per wake cycle | Current battery voltage, for real-time monitoring of the cell. |
+    | **Wake-up Button Pressed** | per wake cycle | Which button woke the device from deep sleep (1 to 4). Resets to 0 after the press is handled. |
 
-    * Controls the light in front of the third button. Defaults to off.
+=== "Events"
 
-    **BTN 4 Light**
+    | Event | What it reports |
+    |-------|-----------------|
+    | **Button 1** | Fires a `click`, `double_click`, `triple_click`, or `hold` event for the first button. Great for automating. |
+    | **Button 2** | Fires a `click`, `double_click`, `triple_click`, or `hold` event for the second button. Great for automating. |
+    | **Button 3** | Fires a `click`, `double_click`, `triple_click`, or `hold` event for the third button. Great for automating. |
+    | **Button 4** | Fires a `click`, `double_click`, `triple_click`, or `hold` event for the fourth button. Great for automating. |
 
-    * Controls the light in front of the fourth button. Defaults to off.
+=== "Configuration"
 
-???+ info "Sensors"
+    | Setting | Default | What it does |
+    |---------|:-------:|--------------|
+    | **ESP Reboot** | — | Restarts the device. Helpful for troubleshooting or refreshing the connection. |
+    | **Sleep Duration** | 24 h | How many hours the BTN-1 stays in deep sleep between wake cycles (only used when **Prevent Sleep** is off). Range is 0 to 800 hours. |
+    | **Prevent Sleep** | On | Keeps the device awake instead of deep-sleeping, so it responds to Home Assistant continuously. Required for OTA updates; turn it off to save battery. While the device is asleep it does not respond to Home Assistant until it wakes again. |
+    | **Factory Reset ESP** | — | Erases settings and returns the device to factory firmware defaults. Disabled by default. |
 
-    **Battery level**
+=== "Diagnostic"
 
-    * Displays the remaining battery percentage. Values range from 0-100%
+    | Entity | Default Update | What it shows |
+    |--------|:--------------:|---------------|
+    | **Apollo Firmware Version** | on boot | The Apollo firmware build installed on the device (for example, `26.3.2.1`). |
+    | **ESPHome Version** | on boot | The ESPHome version the firmware was compiled with. |
+    | **Firmware Update** | — | Shows whether a firmware update is available and lets you update from inside Home Assistant. |
+    | **IP Address** | on connect | The device's IP address on your network. |
+    | **Online** | on change | Connection status of the device to Home Assistant. |
+    | **RSSI** | 60s | Wi-Fi signal strength in dBm. Values closer to 0 are stronger; a weak signal can affect reliability. |
+    | **ESP Temperature** | 60s | Internal temperature of the ESP32 chip. Runs warmer than the room because of the processor and Wi-Fi radio. Disabled by default. |
+    | **Uptime** | 60s | How long the device has been running since its last reboot. |
 
-    **Battery voltage**
-
-    * Represents the current voltage level of the battery for real-time monitoring.
-
-    **Wake-up Button Pressed**
-
-    * Counter to let you know when the wake-up button is pressed. Defaults to 0.
-
-???+ info "Events"
-
-    **Button 1**
-
-    * Displays a Single Click, Double Click, Triple Click and Hold Event for Button 1. Great for automating!
-
-    **Button 2**
-
-    * Displays a Single Click, Double Click, Triple Click and Hold Event for Button 2. Great for automating!
-
-    **Button 3**
-
-    * Displays a Single Click, Double Click, Triple Click and Hold Event for Button 3. Great for automating!
-
-    **Button 4**
-
-    * Displays a Single Click, Double Click, Triple Click and Hold Event for Button 4. Great for automating!
-
-???+ info "Configuration"
-
-    **Prevent Sleep**
-
-    * Prevents the device from going to sleep. When sleeping, your BTN-1 will NOT respond to Home Assistant it is effectively off until it wakes up again. Defaults to ON.
-
-    **Sleep Duration**
-
-    * The number of hours the device should remain in sleep mode before waking up. Defaults to 24 hours.
-
-    **Firmware Update**
-
-    * Indicates whether an update is available or if you are Up-to-date.
-
-??? info "Diagnostic"
-
-    **ESP Temperature**
-
-    * Displays the current temperature of the ESP32 chip. (Disabled by Default)
-
-    **Online**
-
-    * Shows the connection status.
-
-    **RSSI**
-
-    * Displays the Wi-Fi signal strength.
-
-    **Uptime**
-
-    * Shows the time since last reboot.
-
-[Join our Discord if you need more help! :simple-discord:](https://link.apolloautomation.com/discord){                             .md-button }
+[Join our Discord if you need more help! :simple-discord:](https://link.apolloautomation.com/discord){ .md-button }


### PR DESCRIPTION
## What does this implement/fix?

Rebuilds the **BTN-1 Sensor Definitions** page to match the new AIR-1 format (#900): a single Controls / Sensors / Configuration / Diagnostic content-tab strip backed by tables, with a **Default Update** column sourced from firmware (v26.3.2.1), and the new firmware-version entities (**Apollo Firmware Version**, **ESPHome Version**, **IP Address**) added to Diagnostic. Adds an Events tab for the button click/hold events and documents the battery deep-sleep behavior.

Frontmatter stays 4 lines so the Homey mirror's `--8<--` snippet keeps inheriting this page.

## Types of changes

- [ ] Typo / wording fix
- [x] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:

  - [x] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [ ] If new pages were added, nav was updated in `mkdocs.yml`
