### PR TITLE
docs(pump1): rebuild Sensor Definitions with tabbed layout and update intervals

### DIFF
--- a/docs/products/pump1/setup/pump1-sensor-definitions.md
+++ b/docs/products/pump1/setup/pump1-sensor-definitions.md
@@ -4,94 +4,53 @@ description: These are all of the entities exposed by the PUMP-1 to automate on!
 ---
 # Sensor Definitions
 
-This serves as a list of all sensor definitions to help understand what each entity does for your new PUMP-1!
+Once added to Home Assistant you can configure different settings for your PUMP-1. Use the tabs below to see what each entity does, grouped the same way Home Assistant displays them.
 
-???+ info "Controls"
+!!! note "How often readings update"
 
-    **Pump Run Time**
+    The **Default Update** column is how often each entity refreshes. The **Fluid Input** and **Fluid Output** sensors are event-driven, so they report the moment water rises above or falls below the sensor rather than on a fixed interval.
 
-    * Amount of time in seconds to run the pump. Defaults to 10s
+=== "Controls"
 
-    **RGB Light**
+    | Control | What it does |
+    |---------|--------------|
+    | **RGB Light** | One RGB Neopixel LED. Click the light bulb or color wheel to change the color. Use the toggle to turn it on or off. |
+    | **Pump Run Seconds** | Amount of time in seconds to run the pump when you press **Run Pump**. Range is 1 to 120 seconds. Defaults to 10s. |
+    | **Run Pump** | Runs the PUMP-1 pump for the number of seconds set in **Pump Run Seconds**. |
+    | **Run Pump Until Output Wet** | Runs the pump until the **Fluid Output** sensor changes to **Wet**. Disabled by default. |
 
-    * One RGB Neopixel LED. Click on the light bulb or color wheel to change the color. Click on the toggle to turn on or off.
+=== "Sensors"
 
-    **Run Pump**
+    | Sensor | Default Update | Details |
+    |--------|:--------------:|---------|
+    | **Fluid Input** | on change | Ultrasonic sensor at the bottom of the PUMP-1 water bottle that monitors the presence of fluid. Reports **Wet** while water is present and **Dry** once the bottle is empty. |
+    | **Fluid Output** | on change | Ultrasonic sensor you can mount on the exterior of any container to detect water on the other side, such as a Keurig reservoir or fish tank. Reports **Wet** when the water level is above the sensor and **Dry** when it falls below. |
 
-    * Press button for running the PUMP-1 Pump. This will run for the amount of seconds set above in "Pump Run Time".
+=== "Configuration"
 
-    **Run Pump Until Output Wet**
+    | Setting | Default | What it does |
+    |---------|:-------:|--------------|
+    | **ESP Reboot** | — | Restarts the device. Helpful for troubleshooting or refreshing the connection. |
+    | **Max Safe Run Time** | 60 s | Maximum time the pump will run before shutting off. Range is 5 to 600 seconds. |
+    | **Pump Control** | — | Toggles the pump on and off via a switch. Still stopped by **Max Safe Run Time**. Disabled by default. |
+    | **Stop Pump When Input Dry** | Off | Turns the pump off when the ultrasonic sensor at the bottom of the water bottle detects no water. This check is automatically skipped when **Invert Water Logic** is enabled. |
+    | **Stop Pump When Output Wet** | Off | Turns the pump off when the **Fluid Output** sensor (mounted on a Keurig tank, fish tank, or similar container) detects that the water level has risen above its monitoring point. |
+    | **Invert Water Logic** | Off | Flips the meaning of the **Fluid Input** sensor so that **Dry** = destination is low (start pumping) and **Wet** = destination is full (stop pumping). Use this when the Input sensor is placed at the low-water mark inside a destination tank (for example, a CPAP reservoir) rather than at the bottom of a supply bottle. Disabled by default. |
+    | **Auto Refill** | Off | When enabled together with **Invert Water Logic**, the pump automatically starts a fill cycle whenever the **Fluid Input** sensor reads **Dry**. The pump stops when the **Fluid Output** sensor reads **Wet** or when **Max Safe Run Time** is reached, whichever comes first. Requires **Invert Water Logic**. Disabled by default. |
+    | **Pump Safety Override** | Off | Disables the safety features. Disabled by default. |
+    | **Factory Reset ESP** | — | Erases settings and returns the device to factory firmware defaults. Disabled by default. |
 
-    * Press button for running the PUMP-1 Pump. This will run the pump until the Fluid Output changes to Wet. (Disabled by default)
+=== "Diagnostic"
 
-???+ info "Sensors"
+    | Entity | Default Update | What it shows |
+    |--------|:--------------:|---------------|
+    | **Apollo Firmware Version** | on boot | The Apollo firmware build installed on the device (for example, `26.3.2.1`). |
+    | **ESPHome Version** | on boot | The ESPHome version the firmware was compiled with. |
+    | **Firmware Update** | — | Shows whether a firmware update is available and lets you update from inside Home Assistant. |
+    | **IP Address** | on connect | The device's IP address on your network. |
+    | **Online** | on change | Connection status of the device to Home Assistant. |
+    | **RSSI** | 60s | Wi-Fi signal strength in dBm. Values closer to 0 are stronger; a weak signal can affect reliability. |
+    | **ESP Temperature** | 60s | Internal temperature of the ESP32 chip. Runs warmer than the room because of the processor and Wi-Fi radio. Disabled by default. |
+    | **Uptime** | 60s | How long the device has been running since its last reboot. |
 
-    **Fluid Input**
-
-    * This ultrasonic sensor is located at the bottom of the PUMP-1 water bottle and monitors the presence of fluid. The state remains **"Wet"** while water is present in the bottle, and changes to **"Dry"** once the bottle is completely empty. It reports a state of either **"Wet"** or **"Dry"**.
-
-    **Fluid Output**
-
-    * This ultrasonic sensor can be mounted on the exterior of any container where you need to detect the presence of water on the other side, such as a Keurig reservoir or fish tank. It can be attached using adhesive tape or other mounting methods. The sensor reports **"Wet"** when the water level is above the sensor and **"Dry"** when the level falls below it. It reports a state of either **"Wet"** or **"Dry"**.
-
-???+ info "Configuration"
-
-    **ESP Reboot**
-
-    * Performs a restart of the sensor.
-
-    **Firmware Update**
-
-    * Shows whether a firmware update is available.
-
-    **Max Safe Run Time**
-
-    * Maximum time the pump will run before shutting off. Defaults to 100 seconds.
-
-    **Pump Control**
-
-    * Allows you to toggle the pump on and off via a switch. This will still be stopped by the Max Safe Run Time interval set above. (Disabled by default)
-
-    **Stop Pump When Input Dry**
-
-    * This will turn the pump off when the ultrasonic sensor at the bottom of the water bottle detects no water. Note: this check is automatically skipped when **Invert Water Logic** is enabled.
-
-    **Stop Pump When Output Wet**
-
-    * This turns the pump off when the ultrasonic sensor (mounted on a Keurig tank, fish tank, or similar container) detects that the water level has risen above its monitoring point.
-
-    **Invert Water Logic**
-
-    * Flips the meaning of the Fluid Input sensor so that **Dry** = destination is low (start pumping) and **Wet** = destination is full (stop pumping). Use this when the Input sensor is placed at the low-water mark inside a destination tank (e.g. a CPAP reservoir) rather than at the bottom of a supply bottle. (Disabled by default)
-
-    **Auto Refill**
-
-    * When enabled together with **Invert Water Logic**, the pump automatically starts a fill cycle whenever the Fluid Input sensor reads **Dry** (tank level has dropped below the sensor). The pump stops when the Fluid Output sensor reads **Wet** or when **Max Safe Run Time** is reached, whichever comes first. Requires **Invert Water Logic** to be enabled. (Disabled by default)
-
-    **Factory Reset ESP**
-
-    * Factory resets the device (Disabled by default).
-
-    **Pump Safety Override**
-
-    * Allows you to disable the safety features (Disabled by default).
-
-??? info "Diagnostic"
-
-    **ESP Temperature**
-
-    * Displays the current temperature of the ESP32 chip. (Disabled by Default)
-
-    **Online**
-
-    * Shows the connection status.
-
-    **RSSI**
-
-    * Displays the Wi-Fi signal strength.
-
-    **Uptime**
-
-    * Shows the time since last reboot.
-
-[Join our Discord if you need more help! :simple-discord:](https://link.apolloautomation.com/discord){                          .md-button }
+[Join our Discord if you need more help! :simple-discord:](https://link.apolloautomation.com/discord){ .md-button }


### PR DESCRIPTION
## What does this implement/fix?

Rebuilds the **PUMP-1 Sensor Definitions** page to match the new AIR-1 format (#900): a single Controls / Sensors / Configuration / Diagnostic content-tab strip backed by tables, with a **Default Update** column sourced from firmware (v26.3.2.1), and the new firmware-version entities (**Apollo Firmware Version**, **ESPHome Version**, **IP Address**) added to Diagnostic. Also documents the full set of pump-control and safety settings (Invert Water Logic, Auto Refill, Max Safe Run Time, Pump Safety Override).

Frontmatter stays 4 lines so the Homey mirror's `--8<--` snippet keeps inheriting this page.

## Types of changes

- [ ] Typo / wording fix
- [x] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:

  - [x] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [ ] If new pages were added, nav was updated in `mkdocs.yml`
