### PR TITLE
docs(msr2): rebuild Sensor Definitions with tabbed layout and update intervals

### DIFF
--- a/docs/products/msr2/setup/msr2-sensor-definitions.md
+++ b/docs/products/msr2/setup/msr2-sensor-definitions.md
@@ -82,6 +82,7 @@ Once added to Home Assistant you can configure different settings for your MSR-2
     |--------|:--------------:|---------------|
     | **Apollo Firmware Version** | on boot | The Apollo firmware build installed on the device (for example, `26.3.2.1`). |
     | **ESPHome Version** | on boot | The ESPHome version the firmware was compiled with. |
+    | **Firmware Update** | — | Shows whether a firmware update is available and lets you update from inside Home Assistant. Separate from the **Apollo Firmware Version** and **ESPHome Version** sensors above. |
     | **IP Address** | on connect | The device's IP address on your network. |
     | **Online** | on change | Connection status of the device to Home Assistant. |
     | **RSSI** | 60s | Wi-Fi signal strength in dBm. Values closer to 0 are stronger; a weak signal can affect reliability. |

--- a/docs/products/msr2/setup/msr2-sensor-definitions.md
+++ b/docs/products/msr2/setup/msr2-sensor-definitions.md
@@ -4,334 +4,92 @@ description: These are all of the entities exposed by the MSR-2 to automate on!
 ---
 # Sensor Definitions
 
-!!! note "Ensure that the LD2410 firmware version is V2.04.23022511 or later for proper integration functionality. "
-
-    The newer version of the firmware includes an "auto calibrate" function so you might want to test it out!
-
-Once added to Home Assistant you can configure different settings for your sensor. Below is what each setting does.
-
-???+ info "Controls"
-
-    **RGB Light**
-
-    * One RGB Neopixel LED. Click on the light bulb or color wheel to change the color. Click on the toggle to turn on or off.
-
-    **Calibrate SCD40 to 420ppm**
-
-    * A control option to <a href="https://wiki.apolloautomation.com/products/general/calibrating-and-updating/co2-calibration/" target="_blank" rel="noopener">calibrate the SCD40 CO₂ sensor</a> to <a href="https://climate.nasa.gov/vital-signs/carbon-dioxide/?intent=121" target="_blank" rel="noopener">outdoor baseline levels.</a>
-
-???+ info "Sensors"
-
-    **CO<sub>2</sub>**
-
-    * True CO<sub>2</sub> reading from the SCD40. This will be Unknown if you do not have the CO<sub>2</sub> module. SDC40 can be calibrated <a href="https://wiki.apolloautomation.com/products/general/calibrating-and-updating/co2-calibration/" title="CO<sub>2</sub> Calibration" target="_blank" rel="noopener">following this guide</a>.
-
-    **ESP Temperature**
-
-    * This is the temperature of the internal microcontroller. Think of it like your measured CPU temp on your PC.
-
-    **DPS310 Pressure**
-
-    * Measures the air pressure in the environment. Note: A small subset of devices do not include a DPS310 sensor. If this sensor is unknown, your device may be one of these units.
-
-    **DPS310 Temperature**
-
-    * Measures the ambient air temperature using the DPS310 sensor. Note: A small subset of devices do not include a DPS310 sensor. If this sensor is unknown, your device may be one of these units.
-
-    **LTR390 Light**
-
-    * Light level measured in lux by LTR390.
-
-    **LTR390 UV Index**
-
-    * UV index measured by LTR390.
-
-    **Radar Detection Distance**
-
-    * The last detected distance by the radar. This will stay at the last known value so sometimes can be misleading.
-
-    **Radar Move Energy**
-
-    * The amount of movement measured by the LD2410B. Faster movements have higher percentage.
-
-    **Radar Moving Target**
-
-    * Does the radar have a moving target it is tracking.
-
-    **Radar Still Distance**
-
-    * The last measured distance of a still target. It will hold the last value so sometimes can be misleading.
-
-    **Radar Still Energy**
-
-    * The energy of the current still target.
-
-    **Radar Still Target**
-
-    * Does the radar have a still target.
-
-    **Radar Target**
-
-    * Does the radar have a still or moving target. Good for triggering automation.
-
-    **Radar Zone 1 Occupancy**
-
-    * This is a configurable zone. Think of zones like distances from the radar unit. Zone 1 might be from 0 cm to 100 cm from the sensor. This is telling you if there is someone in that zone. The zones can be defined in the configuration section with “Radar End Zone 1”
-
-    **Radar Zone 2 Occupancy**
-
-    * This is a configurable zone. Think of zones like distances from the radar unit. Zone 2 might be from 100 cm to 200 cm from the sensor. This is telling you if there is someone in that zone. The zones can be defined in the configuration section with “Radar End Zone 2”
-
-    **Radar Zone 3 Occupancy**
-
-    * This is a configurable zone. Think of zones like distances from the radar unit. Zone 3 might be from 200 cm to 300 cm from the sensor. This is telling you if there is someone in that zone. The zones can be defined in the configuration section with “Radar End Zone 3”
-
-???+ info "Configuration"
-
-    **ESP Reboot**
-
-    * Performs a restart of the sensor
-
-    **Factory Reset Radar**
-
-    * Sets the radar's move thresholds back to their original values from the manufacturer
-
-    **g0-g8 Move & Still Threshold**
-
-    * Please refer to the radar tuning guide: [Here](https://wiki.apolloautomation.com/products/msr2/setup/zones-ha/)
-
-    **ld2410 Bluetooth**
-
-    * This allows you to turn on the LD2410's Bluetooth. This allows you to connect to the HLK Radar phone app [used for tuning](https://wiki.apolloautomation.com/products/msr2/setup/zones-hlk/).
-
-    **Radar Zone 1 Start**
-
-    * This sets the starting distance for Zone 1 in cm. This is the distance from the sensor to the start of Zone 1
-
-    **DPS Temperature Offset**
-
-    * Offsets the heat from the ESP chip for a more accurate temperature. Note: A small subset of devices do not include a DPS310 sensor. If this option is unknown, your device may be one of these units.
-
-    **ESP Reboot**
-
-    * A control to reboot the ESP32 system.
-
-    **Factory Reset Radar**
-
-    * Resets the radar to its factory settings.
-
-    **Firmware Update**
-
-    * Shows whether a firmware update is available.
-
-    ??? info "Radar End Zones"
-
-        **Radar End Zone 1**
-
-        * This defines “Zone 1” of the radar. It is a distance from the sensor that specifies what “Zone 1” is. It connects to the “Radar Zone 1 Occupancy” sensor. So if this number is set to “100” that means from 0 to 100 centimeters from the sensor is zone 1.
-
-        **Radar End Zone 2**
-
-        * This defines “Zone 2” of the radar. It is a distance from the sensor that specifies what “Zone 2” is. It connects to the “Radar Zone 2 Occupancy” sensor. So if this number is set to “200” that means from zone 2 end distance to 200 centimeters from the sensor is zone 2.
-
-        **Radar End Zone 3**
-
-        * It is a distance from the sensor that specifies what “Zone 3” is. It connects to the “Radar Zone 3 Occupancy” sensor. So if this number is set to “300” that means from zone 2 end distance to 300 centimeters from the sensor is zone 3.
-
-    **Radar Engineering Mode**
-
-    * Used to enable g0-g8 threshold sliders for <a href="https://wiki.apolloautomation.com/products/msr2/setup/zones-ha/" target="_blank" rel="noopener">mmWave tuning</a>.
-
-    **Radar Timeout**
-
-    * Configures the timeout for the radar in seconds.
-
-    **Reduce DB Reporting**
-
-    * A toggle to enable or disable reduced reporting from various entities on the msr-2. This will make multiple entities use filters and not update their state unless a threshold is met - ultimately using less Wi-Fi airtime and less database usage in home assistant.
-
-    **Startup Light Blink**
-
-    * A toggle to enable or disable the blinking of the RGB LED during MSR-2 initial boot.
-
-    ???+ info "Radar Gate Distance Tuning and Timeout"
-
-        ???+ example "Radar Max Move Distance"
-
-            * Maximum distance gate for movement detection. Value between 2 and 8 inclusive
-            * Useful in a bathroom or other scenario where you want to avoid detection after a certain gate number (distance).
-            * Useful for triggering on "radar target" instead of triggering on zone 1/2/3 occupancy instead.
-
-        ???+ example "Radar Max Still Distance "
-
-            * Maximum distance gate for still detection. Value between 2 and 8 inclusive. Defaults to 8.
-            * Useful in a bathroom or other scenario where you want to avoid detection after a certain gate number (distance).
-            * Useful for triggering on "radar target" instead of triggering on zone 1/2/3 occupancy instead.
-
-        ???+ info "Radar Timeout"
-
-            The time in seconds that the radar's presence will stay high after the target is lost.
-
-??? success "Radar Sensors"
-
-    **Radar Detection Distance**
-
-    * Shows the distance to the detected target, measured in cm.
-
-    **Radar Move Energy**
-
-    * Displays the energy of movement detected by the radar, represented as a percentage.
-
-    **Radar Moving Distance**
-
-    * Displays the distance of a moving target, measured in cm.
-
-    **Radar Moving Target**
-
-    * Detects whether a moving target is present.
-
-    **Radar Still Distance**
-
-    * Displays the distance of a still target, measured in cm.
-
-    **Radar Still Energy**
-
-    * Displays the energy detected from still objects.
-
-    **Radar Still Target**
-
-    * Detects whether a still target is present.
-
-    **Radar Target**
-
-    * Overall detection of a target by the radar.
-
-    **Radar Zone 1 Occupancy**
-
-    * Indicates whether Zone 1 is occupied or clear.
-
-    **Radar Zone 2 Occupancy**
-
-    * Indicates whether Zone 2 is occupied or clear.
-
-    **Radar Zone 3 Occupancy**
-
-    * Indicates whether Zone 3 is occupied or clear.
-
-??? info "Radar Gate Configuration"
-
-    !!! warning "Keeping these enabled permanently is bad"
-
-        Please toggle ld2410 Bluetooth on, configure your sensor, then turn ld2410 Bluetooth back off. Otherwise, your Wi-Fi and database could become overwhelmed with excessive traffic.
-
-    **g0 Move Threshold**
-
-    * Configures the movement sensitivity threshold for gate 0.
-
-    **g0 Still Threshold**
-
-    * Configures the stillness sensitivity threshold for gate 0.
-
-    **g1 Move Threshold**
-
-    * Configures the movement sensitivity threshold for gate 1.
-
-    **g1 Still Threshold**
-
-    * Configures the stillness sensitivity threshold for gate 1.
-
-    **g2 Move Threshold**
-
-    * Configures the movement sensitivity threshold for gate 2.
-
-    **g2 Still Threshold**
-
-    * Configures the stillness sensitivity threshold for for gate 2.
-
-    **g3 Move Threshold**
-
-    * Configures the movement sensitivity threshold for gate 3.
-
-    **g3 Still Threshold**
-
-    * Configures the stillness sensitivity threshold for gate 3.
-
-    **g4 Move Threshold**
-
-    * Configures the movement sensitivity threshold for gate 4.
-
-    **g4 Still Threshold**
-
-    * Configures the stillness sensitivity threshold for gate 4.
-
-    **g5 Move Threshold**
-
-    * Configures the movement sensitivity threshold for gate 5.
-
-    **g5 Still Threshold**
-
-    * Configures the stillness sensitivity threshold for gate 5.
-
-    **g6 Move Threshold**
-
-    * Configures the movement sensitivity threshold for gate 6.
-
-    **g6 Still Threshold**
-
-    * Configures the stillness sensitivity threshold for gate 6.
-
-    **g7 Move Threshold**
-
-    * Configures the movement sensitivity threshold for gate 7.
-
-    **g7 Still Threshold**
-
-    * Configures the stillness sensitivity threshold for gate 7.
-
-    **g8 Move Threshold**
-
-    * Configures the movement sensitivity threshold for gate 8.
-
-    **g8 Still Threshold**
-
-    * Configures the stillness sensitivity threshold for gate 8.
-
-??? info "Diagnostic"
-
-    **ESP Temperature**
-
-    * Displays the current temperature of the ESP32 chip.
-
-    **g0 move energy to g8 move energy**
-
-    * Displays the move energy levels for gates g0 through g8
-
-    **g0 move energy to g8 still energy**
-
-    * Displays the still energy levels for gates g0 through g8
-
-    **Online**
-
-    * Shows the connection status.
-
-    **Query Params**
-
-    * Button to query parameters for debugging or advanced configurations.
-
-    **Radar Firmware Version**
-
-    * Displays the current firmware version for the radar.
-
-    **Restart Radar**
-
-    * Button to restart the radar sensor.
-
-    **RSSI**
-
-    * Displays the Wi-Fi signal strength.
-
-    **Uptime**
-
-    * Shows the time since last reboot.
-
-[Join our Discord if you need more help! :simple-discord:](https://link.apolloautomation.com/discord){               .md-button }
+Once added to Home Assistant you can configure different settings for your MSR-2. Use the tabs below to see what each entity does, grouped the same way Home Assistant displays them.
+
+!!! note "How often readings update"
+
+    The **Default Update** column is how often each entity refreshes. Radar entities update in real time as targets move. The **LTR390 Light** and **LTR390 UV Index** sensors use the interval set by the **LTR390 Update Interval** number (60s by default).
+
+!!! note "Ensure that the LD2410 firmware version is V2.04.23022511 or later for proper integration functionality."
+
+    The newer version of the firmware includes an "auto calibrate" function, so you might want to test it out.
+
+=== "Controls"
+
+    | Control | What it does |
+    |---------|--------------|
+    | **RGB Light** | Three RGB Neopixel LEDs. Click the light bulb or color wheel to change the color. Use the toggle to turn them on or off. |
+    | **Calibrate SCD40 To 420ppm** | Forces a fresh-air calibration of the SCD40 CO₂ sensor to the <a href="https://wiki.apolloautomation.com/products/general/calibrating-and-updating/co2-calibration/" target="_blank" rel="noopener">outdoor baseline</a> (about <a href="https://climate.nasa.gov/vital-signs/carbon-dioxide/?intent=121" target="_blank" rel="noopener">420 ppm</a>). Run it outdoors or next to an open window. |
+
+=== "Sensors"
+
+    #### Air quality &amp; light
+
+    | Sensor | Default Update | Details |
+    |--------|:--------------:|---------|
+    | **CO2** | 60s | True NDIR reading from the SCD40. Shows *Unknown* if you do not have the CO₂ module. You can <a href="https://wiki.apolloautomation.com/products/general/calibrating-and-updating/co2-calibration/" target="_blank" rel="noopener">re-calibrate it to the outdoor baseline</a>. |
+    | **DPS310 Pressure** | 30s | Barometric air pressure. A small subset of devices do not include a DPS310 sensor. If this reads *Unknown*, your device may be one of these units. |
+    | **DPS310 Temperature** | 30s | Ambient air temperature from the DPS310. Adjusted by the **DPS Temperature Offset**. A small subset of devices do not include a DPS310 sensor. |
+    | **LTR390 Light** | 60s* | Ambient light level in lux. *Polls at the **LTR390 Update Interval** (60s by default). |
+    | **LTR390 UV Index** | 60s* | UV index measured by the LTR390. *Polls at the **LTR390 Update Interval**. |
+
+    #### Radar (LD2410)
+
+    | Sensor | Default Update | Details |
+    |--------|:--------------:|---------|
+    | **Radar Target** | real-time | Whether the radar detects a still or moving target. Good for triggering occupancy automations. |
+    | **Radar Moving Target** | real-time | Whether a moving target is currently detected. |
+    | **Radar Still Target** | real-time | Whether a stationary target is currently detected. |
+    | **Radar Moving Distance** | real-time | Distance to a moving target in cm. Reports *Unknown* when no moving target is present. |
+    | **Radar Still Distance** | real-time | Distance to a still target in cm. Reports *Unknown* when no still target is present. |
+    | **Radar Detection Distance** | real-time | Last detected distance from the radar in cm. Holds the last value, so it can be misleading when nothing is present. |
+    | **Radar Move Energy** | real-time | Amount of movement measured by the LD2410. Faster movement reads as a higher percentage. |
+    | **Radar Still Energy** | real-time | Energy of the current still target. |
+    | **Radar Zone 1 Occupancy** | real-time | Whether someone is in Zone 1. Zones are distance bands from the sensor, set with **Radar Zone 1 Start** and **Radar End Zone 1**. |
+    | **Radar Zone 2 Occupancy** | real-time | Whether someone is in Zone 2, from the end of Zone 1 to **Radar End Zone 2**. |
+    | **Radar Zone 3 Occupancy** | real-time | Whether someone is in Zone 3, from the end of Zone 2 to **Radar End Zone 3**. |
+    | **Radar Zone Occupancy** | real-time | Whether any of Zone 1, 2, or 3 is occupied. |
+
+=== "Configuration"
+
+    | Setting | Default | What it does |
+    |---------|:-------:|--------------|
+    | **ESP Reboot** | — | Restarts the device. Helpful for troubleshooting or refreshing the connection. |
+    | **Factory Reset ESP** | — | Erases settings and returns the device to factory firmware defaults. Disabled by default. |
+    | **Factory Reset Radar** | — | Resets the LD2410 radar to its factory move and still thresholds. |
+    | **Restart Radar** | — | Restarts the LD2410 radar module. |
+    | **Radar Timeout** | — | How long presence stays detected, in seconds, after the target is lost. |
+    | **Radar Max Move Distance** | — | Maximum distance gate for movement detection (gate 2 to 8). Use it to ignore movement past a chosen distance. |
+    | **Radar Max Still Distance** | — | Maximum distance gate for still detection (gate 2 to 8). Use it to ignore still targets past a chosen distance. |
+    | **Radar Zone 1 Start** | 0 cm | Start distance of Zone 1 from the sensor, in cm (0 to 800). |
+    | **Radar End Zone 1** | 50 cm | End distance of Zone 1 from the sensor, in cm. From **Radar Zone 1 Start** to this value is Zone 1. |
+    | **Radar End Zone 2** | 150 cm | End distance of Zone 2, in cm. From the end of Zone 1 to this value is Zone 2. |
+    | **Radar End Zone 3** | 250 cm | End distance of Zone 3, in cm. From the end of Zone 2 to this value is Zone 3. |
+    | **Radar Engineering Mode** | — | Enables the g0-g8 threshold sliders for <a href="https://wiki.apolloautomation.com/products/msr2/setup/zones-ha/" target="_blank" rel="noopener">mmWave tuning</a>. |
+    | **g0-g8 move threshold** | — | Movement sensitivity threshold for each gate (g0 through g8). See the <a href="https://wiki.apolloautomation.com/products/msr2/setup/zones-ha/" target="_blank" rel="noopener">radar tuning guide</a>. |
+    | **g0-g8 still threshold** | — | Stillness sensitivity threshold for each gate (g0 through g8). See the <a href="https://wiki.apolloautomation.com/products/msr2/setup/zones-ha/" target="_blank" rel="noopener">radar tuning guide</a>. |
+    | **ld2410 Gate Size** | — | Distance resolution per gate on the LD2410. Disabled by default. |
+    | **ld2410 Bluetooth** | Off | Turns on the LD2410's Bluetooth so you can connect with the HLK Radartool phone app for <a href="https://wiki.apolloautomation.com/products/msr2/setup/zones-hlk/" target="_blank" rel="noopener">tuning</a>. Turned off at boot. |
+    | **LTR390 Update Interval** | 60 s | How often the LTR390 light and UV sensors poll (1 to 300 seconds). Disabled by default. |
+    | **DPS310 Pressure Offset** | 0.0 hPa | Calibration offset for the DPS310 pressure reading (-100 to +100 hPa in 0.1 hPa steps). Disabled by default. A small subset of devices do not include a DPS310 sensor; if this reads *Unknown*, your device may be one of these units. |
+    | **DPS Temperature Offset** | 14.54 °C | Offsets heat from the ESP chip for a more accurate DPS310 temperature reading. A small subset of devices do not include a DPS310 sensor. |
+    | **Reduce DB Reporting** | Off | Applies filters so many entities only report when they cross a threshold, using less Wi-Fi airtime and less Home Assistant database space. |
+    | **Startup Light Blink** | On | Blinks the RGB LED during the MSR-2's initial boot. |
+
+=== "Diagnostic"
+
+    | Entity | Default Update | What it shows |
+    |--------|:--------------:|---------------|
+    | **Apollo Firmware Version** | on boot | The Apollo firmware build installed on the device (for example, `26.3.2.1`). |
+    | **ESPHome Version** | on boot | The ESPHome version the firmware was compiled with. |
+    | **IP Address** | on connect | The device's IP address on your network. |
+    | **Online** | on change | Connection status of the device to Home Assistant. |
+    | **RSSI** | 60s | Wi-Fi signal strength in dBm. Values closer to 0 are stronger; a weak signal can affect reliability. |
+    | **ESP Temperature** | 60s | Internal temperature of the ESP32 chip. Runs warmer than the room because of the processor and Wi-Fi radio. |
+    | **Uptime** | 60s | How long the device has been running since its last reboot. |
+    | **Radar Firmware Version** | on boot | Firmware version installed on the LD2410 radar module. |
+    | **query params** | — | Queries the LD2410's current parameters for debugging and advanced tuning. |
+    | **g0 move energy to g8 move energy** | real-time | Live move-energy level for each gate (g0 through g8). |
+    | **g0 still energy to g8 still energy** | real-time | Live still-energy level for each gate (g0 through g8). |
+
+[Join our Discord if you need more help! :simple-discord:](https://link.apolloautomation.com/discord){ .md-button }


### PR DESCRIPTION
## What does this implement/fix?

Rebuilds the **MSR-2 Sensor Definitions** page to match the new AIR-1 format (#900): a single Controls / Sensors / Configuration / Diagnostic content-tab strip backed by tables, with the Sensors tab split into **Air quality & light** and **Radar (LD2410)** subsections. Adds a **Default Update** column sourced from firmware (v26.3.2.1) and the new firmware-version entities (**Apollo Firmware Version**, **ESPHome Version**, **IP Address**).

Preserves the DPS310 "small subset of devices" note and the LD2410 firmware-version requirement note. The Homey mirror inherits this page automatically via its existing `--8<--` snippet.

## Types of changes

- [ ] Typo / wording fix
- [x] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:

  - [x] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [ ] If new pages were added, nav was updated in `mkdocs.yml`
