### PR TITLE
docs(starter-kit): next-step and community buttons on module pages

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/modules/button-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/button-module.md
@@ -119,3 +119,14 @@ With the device back online, the button entity is live on the web server. <a hre
 !!! success "Your button module is now ready for you to use in automations!"
 
     Your Button Module is now ready for some fun tasks.. like toggling lights on and off in your room, watering your plants, and more!
+
+## Try it in an automation
+
+Your button is live. Now make it trigger something:
+
+<a href="/products/ESPHome-Starter-Kit/automations/button-controlled-leds/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Button Controlled LEDs </a>
+<a href="/products/ESPHome-Starter-Kit/automations/play-a-tune/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Play a Tune </a>
+<a href="/products/ESPHome-Starter-Kit/automations/press-to-check-climate/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Press to Check Climate </a>
+
+[Join our Discord :simple-discord:](https://link.apolloautomation.com/discord){ .md-button .md-button--discord }
+[Community Forum :material-forum:](https://forum.apolloautomation.com/){ .md-button .md-button--primary }

--- a/docs/products/ESPHome-Starter-Kit/modules/motion-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/motion-module.md
@@ -118,3 +118,12 @@ With the device back online, the Motion entity is live on the web server. <a hre
 !!! success "Your Motion module is now ready to use in automations!"
 
     You're now ready to make automations around occupancy in your home!
+
+## Try it in an automation
+
+Your motion sensor is live. Put it to work:
+
+<a href="/products/ESPHome-Starter-Kit/automations/motion-activated-light/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Motion-Activated Light </a>
+
+[Join our Discord :simple-discord:](https://link.apolloautomation.com/discord){ .md-button .md-button--discord }
+[Community Forum :material-forum:](https://forum.apolloautomation.com/){ .md-button .md-button--primary }

--- a/docs/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module.md
@@ -128,3 +128,15 @@ The buzzer doesn't have its own web server control, since it's an output rather 
 !!! success "Your LED & Buzzer notification module is wired up!"
 
     Your LED & Buzzer Module is now ready for some fun tasks.. like toggling lights on and off, playing with the colors, or using the buzzer to play fun tunes!
+
+## Try it in an automation
+
+Your notification module is ready. Drive it from any of these automations:
+
+<a href="/products/ESPHome-Starter-Kit/automations/button-controlled-leds/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Button Controlled LEDs </a>
+<a href="/products/ESPHome-Starter-Kit/automations/play-a-tune/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Play a Tune </a>
+<a href="/products/ESPHome-Starter-Kit/automations/temp-reactive-leds/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Temp-Reactive LEDs </a>
+<a href="/products/ESPHome-Starter-Kit/automations/motion-activated-light/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Motion-Activated Light </a>
+
+[Join our Discord :simple-discord:](https://link.apolloautomation.com/discord){ .md-button .md-button--discord }
+[Community Forum :material-forum:](https://forum.apolloautomation.com/){ .md-button .md-button--primary }

--- a/docs/products/ESPHome-Starter-Kit/modules/temperature-humidity-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/temperature-humidity-module.md
@@ -126,3 +126,13 @@ With the device back online, the temperature and humidity entities are live on t
 !!! success "Your Temperature and Humidity module is wired up"
 
     You now have a trustworthy temp and humidity sensor to place anywhere in your home!
+
+## Try it in an automation
+
+Your sensor is reporting. Now make it drive something:
+
+<a href="/products/ESPHome-Starter-Kit/automations/temp-reactive-leds/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Temp-Reactive LEDs </a>
+<a href="/products/ESPHome-Starter-Kit/automations/press-to-check-climate/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Press to Check Climate </a>
+
+[Join our Discord :simple-discord:](https://link.apolloautomation.com/discord){ .md-button .md-button--discord }
+[Community Forum :material-forum:](https://forum.apolloautomation.com/){ .md-button .md-button--primary }

--- a/docs/products/ESPHome-Starter-Kit/start-here.md
+++ b/docs/products/ESPHome-Starter-Kit/start-here.md
@@ -15,7 +15,7 @@ By the end of this wiki you'll know how to:
 
 ## What's in the kit
 
-Your kit arrives as a single snap-apart panel that includes the ESP32-C6 main board along with a selection of interchangeable modules. The kit also includes three ribbon cables used to connect the modules together, and a stand for the LED & Buzzer module.
+Your kit arrives as a single snap-apart panel that includes the ESP32-C6 main board along with a selection of interchangeable modules. The kit also includes three ribbon cables for connecting modules to the main board, one more than any project uses at once so you always have a spare, plus a stand for the LED & Buzzer module.
 
 ![](../../assets/esphome-starter-kit-whats-in-the-box.png)
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -170,3 +170,19 @@ article.md-typeset .md-button img {
   vertical-align: -0.2em;
   margin-right: 0.4em;
 }
+
+/* Discord-branded button variant. Discord "blurple" so the Join-our-Discord
+   call to action reads as its own thing next to the accent-colored primary
+   buttons. Class lives here (not an inline style) so CloudCannon's WYSIWYG
+   keeps it when the page is round-tripped. */
+.md-typeset .md-button--discord {
+  background-color: #5865f2;
+  border-color: #5865f2;
+  color: #fff;
+}
+.md-typeset .md-button--discord:focus,
+.md-typeset .md-button--discord:hover {
+  background-color: #4752c4;
+  border-color: #4752c4;
+  color: #fff;
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

Adds next-step navigation and community links to the ESPHome Starter Kit module pages.

- A **Try it in an automation** section at the bottom of each module page (Button, Motion, Temperature & Humidity, LED & Buzzer), with the stylized ESPHome buttons used elsewhere in the wiki, linking to each automation that uses that module.
- A **Join our Discord** + **Community Forum** button pair beneath those, so every module page has a clear path to help and community.
- A small reusable `.md-button--discord` class (Discord blurple) in `extra.css` for the Discord button, kept in CSS rather than inline so the CloudCannon WYSIWYG keeps it on round-trip.
- On **Start Here**, clarifies that the kit ships a spare ribbon cable (three total, one more than any project uses at once) instead of just stating the count.

Previewed locally with `mkdocs serve`. No pages were moved, renamed, or added, so no `mkdocs.yml` nav or redirect changes are needed.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [x] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [ ] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Try it in an automation" sections to module guides with curated links to relevant automation tutorials and examples.
  * Integrated Discord and Community Forum links throughout module documentation for community engagement.
  * Clarified kit contents description regarding ribbon cables.

* **Style**
  * Enhanced button styling to support Discord-branded button variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->