### PR TITLE
Sync dev → main: sleep/battery framing + OTA update note

### DIFF
--- a/docs/products/air1/setup/sensor-definitions.md
+++ b/docs/products/air1/setup/sensor-definitions.md
@@ -10,7 +10,9 @@ Once added to Home Assistant you can configure different settings for your AIR-1
 
 !!! note "How often readings update"
 
-    The **Default Update** column is how often each sensor refreshes while the AIR-1 is awake. By default **Prevent Sleep** is on, so the device stays awake and reports continuously at these intervals. If you turn **Prevent Sleep** off (for battery use), the AIR-1 wakes for about 2 minutes, reports, then deep-sleeps for the **Sleep Duration**.
+    The **Default Update** column is how often each sensor refreshes while the AIR-1 is awake. By default **Prevent Sleep** is on, so the device stays awake and reports continuously at these intervals. Turn **Prevent Sleep** off to let the AIR-1 deep-sleep between readings for more accurate onboard SEN55 temperature and humidity (the ESP chip's heat skews them while it is awake); it then wakes for about 2 minutes, reports, and sleeps for the **Sleep Duration**.
+
+    To update firmware on a sleeping device, just click **Update** on the **Firmware Update** entity and it installs the next time the device wakes (the firmware keeps itself awake until the update finishes, so you don't need to do anything else). The optional [OTA helper](https://wiki.apolloautomation.com/products/general/battery-sensors/awake-ha-helper/) is a separate toggle that overrides **Prevent Sleep** to keep a device awake on demand.
 
 === "Controls"
 
@@ -65,7 +67,7 @@ Once added to Home Assistant you can configure different settings for your AIR-1
     | **SEN55 Humidity Offset** | 0 % | Calibrates the SEN55 humidity reading to a known value. See the <a href="https://wiki.apolloautomation.com/products/general/temp-hum-calibration/" target="_blank" rel="noopener">temperature &amp; humidity calibration guide</a>. |
     | **DPS310 Pressure Offset** | 0.0 hPa | Applies a calibration offset to the DPS310 pressure reading. Range is -100 to +100 hPa in 0.1 hPa steps. Disabled by default. A small subset of devices do not include a DPS310 sensor; if this option reads *Unknown*, your device may be one of these units. |
     | **Sleep Duration** | 5 min | How long the AIR-1 stays in deep sleep between wake cycles (only used when **Prevent Sleep** is off). |
-    | **Prevent Sleep** | On | Keeps the device awake instead of deep-sleeping, so it reports continuously. Required for OTA updates and live readings; turn it off to save power on battery. |
+    | **Prevent Sleep** | On | Keeps the device awake instead of deep-sleeping, so it reports continuously. Turn it off to let the AIR-1 deep-sleep between readings for more accurate onboard SEN55 temperature and humidity. |
     | **Factory Reset ESP** | — | Erases settings and returns the device to factory firmware defaults. Disabled by default. |
 
 === "Diagnostic"

--- a/docs/products/plt1/setup/plt1-sensor-definitions.md
+++ b/docs/products/plt1/setup/plt1-sensor-definitions.md
@@ -8,16 +8,15 @@ Once added to Home Assistant you can configure different settings for your PLT-1
 
 ![PLT-1 Sensor Data](/assets/screenshot-2024-10-03-at-4-10-25-pm.png)
 
-!!! note "How the PLT-1 sleeps"
+!!! tip "Automate your plant care"
 
-    The PLT-1 is a battery-powered deep-sleep sensor. By default it wakes, reports its readings, then deep-sleeps for the **Sleep Duration**. When it connects to Home Assistant it waits a few seconds, sends one full set of readings, then sleeps again, unless **Prevent Sleep** is on or the device is in OTA mode. Turn **Prevent Sleep** on to keep the device awake for live readings and OTA updates (this uses much more battery). The **Default Update** column is how often each entity refreshes while the PLT-1 is awake.
+    Want soil-moisture alerts and watering reminders? Import the [PLT-1 Plant Sensor Alerts blueprint](https://wiki.apolloautomation.com/products/plt1/examples/blueprint/) to get low-moisture notifications and automations without building them by hand.
 
 === "Controls"
 
     | Control | What it does |
     |---------|--------------|
     | **RGB Light** | One RGB Neopixel LED. Click the light bulb or color wheel to change the color. Use the toggle to turn it on or off. Useful for visual plant-health alerts (for example, green when fine, red when soil is too dry). |
-    | **Accessory Power** | Controls power delivery to the sensor board. On sends power to the whole device. Off powers only the ESP chip, which also disables the RGB Light. Battery models only. |
 
 === "Sensors"
 
@@ -29,8 +28,6 @@ Once added to Home Assistant you can configure different settings for your PLT-1
     | **Air Humidity** | 60s | Relative humidity of the air around the plant from the AHT20 sensor. Adjusted by the **Air Humidity Offset**. |
     | **LTR390 Light** | 60s* | Ambient light level in lux. *Polls at the **LTR390 Update Interval** (60s by default). |
     | **LTR390 UV Index** | 60s* | UV index measured by the LTR390. *Polls at the **LTR390 Update Interval**. |
-    | **Battery level** | 60s | Battery charge as a percentage, from the MAX17048 fuel gauge. Battery models only. |
-    | **Battery voltage** | 60s | Battery voltage from the MAX17048 fuel gauge. Battery models only. |
     | **Soil ADC** | 5s | Raw soil voltage from the ADC, used to calculate **Soil Moisture**. Diagnostic, disabled by default. |
 
 === "Configuration"
@@ -43,8 +40,8 @@ Once added to Home Assistant you can configure different settings for your PLT-1
     | **Air Temperature Offset** | 0.0 °C | Calibration offset applied to the **Air Temperature** reading. |
     | **Air Humidity Offset** | 0 % | Calibration offset applied to the **Air Humidity** reading. |
     | **LTR390 Update Interval** | 60 s | How often the LTR390 light and UV sensors poll (1 to 300 seconds). |
-    | **Sleep Duration** | 12 h (battery) / 5 min (USB) | How long the PLT-1 deep-sleeps between wake cycles. Battery models default to 12 hours; USB-powered models default to 5 minutes. |
-    | **Prevent Sleep** | On | Keeps the device awake instead of deep-sleeping, so it reports continuously. Required for OTA updates and live readings. Turn it off to save battery. |
+    | **Sleep Duration** | 5 min | How long the PLT-1 deep-sleeps between readings when **Prevent Sleep** is off. |
+    | **Prevent Sleep** | On | Keeps the device awake instead of deep-sleeping, so it reports continuously. Turn it off to let the PLT-1 deep-sleep between readings for more accurate onboard AHT20 temperature and humidity. |
     | **Factory Reset ESP** | — | Erases settings and returns the device to factory firmware defaults. Disabled by default. |
 
 === "Diagnostic"
@@ -53,7 +50,7 @@ Once added to Home Assistant you can configure different settings for your PLT-1
     |--------|:--------------:|---------------|
     | **Apollo Firmware Version** | on boot | The Apollo firmware build installed on the device (for example, `26.3.2.1`). |
     | **ESPHome Version** | on boot | The ESPHome version the firmware was compiled with. |
-    | **Firmware Update** | — | Shows whether a firmware update is available and lets you update from inside Home Assistant. |
+    | **Firmware Update** | — | Shows whether a firmware update is available. Click **Update** and it installs the next time the device wakes; the optional [OTA helper](https://wiki.apolloautomation.com/products/general/battery-sensors/awake-ha-helper/) overrides **Prevent Sleep** to keep the device awake on demand. Separate from the **Apollo Firmware Version** and **ESPHome Version** sensors. |
     | **IP Address** | on connect | The device's IP address on your network. |
     | **Online** | on change | Connection status of the device to Home Assistant. |
     | **RSSI** | 60s | Wi-Fi signal strength in dBm. Values closer to 0 are stronger; a weak signal can affect reliability. |

--- a/docs/products/plt1b/setup/plt1b-sensor-definitions.md
+++ b/docs/products/plt1b/setup/plt1b-sensor-definitions.md
@@ -8,9 +8,11 @@ Once added to Home Assistant you can configure different settings for your PLT-1
 
 ![PLT-1B Sensor Data](/assets/screenshot-2024-10-03-at-4-10-25-pm.png)
 
-!!! note "How often readings update"
+!!! note "How the PLT-1B sleeps"
 
-    The **Default Update** column is how often each sensor refreshes while the PLT-1B is awake. The PLT-1B is the 18650-battery variant, so by default it deep-sleeps to save power. By default **Prevent Sleep** is on, which keeps the device awake and reporting continuously at these intervals. If you turn **Prevent Sleep** off, the PLT-1B wakes for about 90 seconds, reports its readings, then deep-sleeps for the **Sleep Duration** before waking again.
+    The PLT-1B runs on an 18650 battery. By default **Prevent Sleep** is on, so it stays awake and reports continuously at these intervals, which drains the battery. Turn **Prevent Sleep** off to let it deep-sleep between readings for the **Sleep Duration** (12h) and conserve the cell: it wakes for about 90 seconds, reports its readings, then sleeps again. The **Default Update** column is how often each sensor refreshes while it is awake.
+
+    To update firmware on a sleeping device, just click **Update** on the **Firmware Update** entity and it installs the next time the device wakes (the firmware keeps itself awake until the update finishes, so you don't need to do anything else). The optional [OTA helper](https://wiki.apolloautomation.com/products/general/battery-sensors/awake-ha-helper/) is a separate toggle that overrides **Prevent Sleep** to keep a device awake on demand.
 
 === "Controls"
 

--- a/docs/products/temp1/setup/temp1-sensor-definitions.md
+++ b/docs/products/temp1/setup/temp1-sensor-definitions.md
@@ -8,7 +8,9 @@ Once added to Home Assistant you can configure different settings for your TEMP-
 
 !!! note "How often readings update"
 
-    The **Default Update** column is how often each sensor refreshes while the TEMP-1 is awake. By default **Prevent Sleep** is on, so the device stays awake and reports continuously at these intervals. If you turn **Prevent Sleep** off (for battery use), the TEMP-1 wakes for about 90 seconds, reports, then deep-sleeps for the **Sleep Duration**.
+    The **Default Update** column is how often each sensor refreshes while the TEMP-1 is awake. By default **Prevent Sleep** is on, so the device stays awake and reports continuously at these intervals. Turn **Prevent Sleep** off to let the TEMP-1 deep-sleep between readings for more accurate onboard AHT20 temperature and humidity (the ESP chip's heat skews them while it is awake); it then wakes for about 90 seconds, reports, and sleeps for the **Sleep Duration**.
+
+    To update firmware on a sleeping device, just click **Update** on the **Firmware Update** entity and it installs the next time the device wakes (the firmware keeps itself awake until the update finishes, so you don't need to do anything else). The optional [OTA helper](https://wiki.apolloautomation.com/products/general/battery-sensors/awake-ha-helper/) is a separate toggle that overrides **Prevent Sleep** to keep a device awake on demand.
 
 === "Controls"
 
@@ -44,7 +46,7 @@ Once added to Home Assistant you can configure different settings for your TEMP-
     | **Probe Temp Difference Threshold** | 0.0 °C | Temperature change that triggers a report when **Notify Only Outside Temp Difference** is on. Disabled by default. |
     | **Notify Only Outside Temp Difference** | Off | Wakes the device to report only when the probe temperature changes by more than the **Probe Temp Difference Threshold**, instead of every wake cycle. Disabled by default. |
     | **Sleep Duration** | 8 min | How long the TEMP-1 stays in deep sleep between wake cycles (only used when **Prevent Sleep** is off). |
-    | **Prevent Sleep** | On | Keeps the device awake instead of deep-sleeping, so it reports continuously. Required for OTA updates and live readings; turn it off to save power on battery. |
+    | **Prevent Sleep** | On | Keeps the device awake instead of deep-sleeping, so it reports continuously. Turn it off to let the TEMP-1 deep-sleep between readings for more accurate onboard AHT20 temperature and humidity. |
     | **Factory Reset ESP** | — | Erases settings and returns the device to factory firmware defaults. Disabled by default. |
 
 === "Diagnostic"

--- a/docs/products/temp1b/setup/temp1b-sensor-definitions.md
+++ b/docs/products/temp1b/setup/temp1b-sensor-definitions.md
@@ -8,7 +8,9 @@ Once added to Home Assistant you can configure different settings for your TEMP-
 
 !!! note "How often readings update"
 
-    The **Default Update** column is how often each entity refreshes while the TEMP-1B is awake. The TEMP-1B is a battery deep-sleep device. By default **Prevent Sleep** is on, so it stays awake and reports continuously at these intervals. If you turn **Prevent Sleep** off, the device wakes, reports its values, then deep-sleeps for the **Sleep Duration** before waking again.
+    The **Default Update** column is how often each entity refreshes while the TEMP-1B is awake. The TEMP-1B runs on a battery, and by default **Prevent Sleep** is on, so it stays awake and reports continuously at these intervals (which drains the battery). Turn **Prevent Sleep** off to let it deep-sleep between readings and conserve the battery: it wakes, reports, then sleeps for the **Sleep Duration** before waking again.
+
+    To update firmware on a sleeping device, just click **Update** on the **Firmware Update** entity and it installs the next time the device wakes (the firmware keeps itself awake until the update finishes, so you don't need to do anything else). The optional [OTA helper](https://wiki.apolloautomation.com/products/general/battery-sensors/awake-ha-helper/) is a separate toggle that overrides **Prevent Sleep** to keep a device awake on demand.
 
 === "Controls"
 


### PR DESCRIPTION
Sync `dev` into `main`. Corrects the sleep/battery framing on AIR-1, TEMP-1, TEMP-1B, PLT-1, PLT-1B and adds the firmware-update-on-wake note (#915).