### PR TITLE
docs(starter-kit): add community help CTA snippet to every page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,12 @@ Read the full style guide, but these are the ones worth checking twice:
   same-product stepping-stone box linking easier automations. Pill and
   box styles live in `docs/stylesheets/extra.css`; never inline colors.
   See [Automation difficulty](STYLE_GUIDE.md#10-automation-difficulty).
+- Every page under the ESPHome Starter Kit product (modules, tutorials,
+  automations, learn-the-basics, FAQ, start-here, first-steps) must end
+  with the community CTA snippet:
+  `--8<-- "_snippets/community-help.md"`. To change the CTA copy or
+  buttons, edit the snippet file, never the include line on a page.
+  See [Community CTA on starter-kit pages](STYLE_GUIDE.md#11-community-cta-on-starter-kit-pages).
 
 ## Keep the style guide current
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,7 @@ The full writing and formatting rules live in [STYLE_GUIDE.md](STYLE_GUIDE.md). 
 - **ESPHome** is the only correct casing.
 - **No em dashes** anywhere in user-facing copy.
 - **Automation pages** carry a difficulty pill (`Level 1 Starter` to `Level 5 Pro`) under the title; harder pages can link easier ones in a stepping-stone box. See [Automation difficulty](STYLE_GUIDE.md#10-automation-difficulty).
+- **Starter-kit pages** end with the community CTA snippet (`--8<-- "_snippets/community-help.md"`). Edit the snippet, not the page, when the CTA copy changes. See [Community CTA on starter-kit pages](STYLE_GUIDE.md#11-community-cta-on-starter-kit-pages).
 
 Mechanical conventions:
 - MkDocs Material: see https://squidfunk.github.io/mkdocs-material/ for admonitions, tabs, and content tabs syntax

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -450,7 +450,39 @@ colors on the page.
 
 ---
 
-## 11. When in doubt
+## 11. Community CTA on starter-kit pages
+
+Every page under the **ESPHome Starter Kit** product carries the same
+community call-to-action at the bottom: a friendly note admonition titled
+"New to ESPHome? We're here to help." with links to Discord and the
+Community Forum. The copy and buttons live in a single snippet so the
+CTA stays consistent across the product and only needs one edit to update.
+
+**Source of truth:** `docs/_snippets/community-help.md`
+
+**Where to include it:** at the very bottom of any starter-kit page (after
+any existing "Try it in an automation" buttons, "Next Steps" buttons, or
+closing success admonition). One blank line of separation from the
+content above is enough.
+
+**How to include it:**
+
+```markdown
+--8<-- "_snippets/community-help.md"
+```
+
+**When you add a new starter-kit page**, end it with this include before
+opening the PR. **When you edit the CTA copy** (adding a new channel,
+rewording the prompt, swapping button labels), edit the snippet file
+itself, never the include line on a page.
+
+The snippet uses the standard `note` admonition flavor for visual
+consistency with the kit's other admonitions ("Before you start", tips,
+warnings); don't swap it for `tip` or `info` on a per-page basis.
+
+---
+
+## 12. When in doubt
 
 If a rule above conflicts with clarity for the reader, clarity wins.
 Open an issue or PR proposing the rule change so the guide stays

--- a/docs/_snippets/community-help.md
+++ b/docs/_snippets/community-help.md
@@ -1,0 +1,6 @@
+!!! note "New to ESPHome? We're here to help."
+
+    Stuck on a step or want to show off what you built? Ask questions and share projects with the Apollo community.
+
+    [Join our Discord :simple-discord:](https://link.apolloautomation.com/discord){ .md-button .md-button--discord }
+    [Community Forum :material-forum:](https://forum.apolloautomation.com/){ .md-button .md-button--primary }

--- a/docs/products/ESPHome-Starter-Kit/automations/button-controlled-leds.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/button-controlled-leds.md
@@ -97,3 +97,5 @@ With the device back online, press the button on the Button module. You should h
 #### Next Steps
 
 <a href="../../tutorials/light-effects/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Next - Light Effects</a>
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/automations/motion-activated-light.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/motion-activated-light.md
@@ -128,3 +128,5 @@ Right now the light turns on with motion but never turns off. Add a second trigg
 !!! success "You've built a motion-activated light!"
 
     Same trigger-then-action pattern, new trigger. Swap the action (play a buzzer tune, dim the light, send a notification) or the trigger (a button, a temperature threshold, a schedule) and you have a new automation.
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/automations/play-a-tune.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/play-a-tune.md
@@ -141,3 +141,5 @@ Want more? <a href="https://picaxe.com/rtttl-ringtones-for-tune-command/" title=
     Same trigger-then-action pattern, new action. Swap the trigger (motion, a temperature threshold, a schedule) or the tune, and you have a new automation.
 
 [Check out these Holiday themed buzzer examples too! :material-music-note:](https://wiki.apolloautomation.com/products/general/holiday-songs/){ .md-button .md-button--primary }
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/automations/press-to-check-climate.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/press-to-check-climate.md
@@ -644,3 +644,6 @@ With the device back online, press the button on the Button module. The Onboard 
 The same trigger / condition / delay / light pattern works with any sensor and any light on your kit. Swap the temperature sensor for a CO2 reading, the button trigger for a motion event, or the Onboard RGB LED for the LED & Buzzer module's `rgb_leds` strip, and you have a new readout. Then bring it into Home Assistant so you can tune it from anywhere.
 
 <a href="../../tutorials/connect-to-home-assistant/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Next - Connect to Home Assistant</a>
+
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/automations/temp-reactive-leds.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/temp-reactive-leds.md
@@ -163,3 +163,6 @@ Open the Comfortable and Hot triggers in the GUI and edit the **Above** / **Belo
 #### Next Steps
 
 <a href="../../tutorials/connect-to-home-assistant/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Next - Connect to Home Assistant</a>
+
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/faq.md
+++ b/docs/products/ESPHome-Starter-Kit/faq.md
@@ -67,3 +67,6 @@ description: Frequently asked questions about the ESPHome Starter Kit, ESPHome D
 * The ESP32-C6 is a modern microcontroller from Espressif that brings Wi-Fi, Bluetooth LE, and Thread support to a single chip. It is the same family of silicon used in commercially certified smart home products, and gives learners a future-ready platform that supports the same open standards used in production smart home devices.
 
 [Click here to join our Discord for fast support! :simple-discord:](https://link.apolloautomation.com/discord){ .md-button .md-button--primary }
+
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/learning-the-basics/core-components.md
+++ b/docs/products/ESPHome-Starter-Kit/learning-the-basics/core-components.md
@@ -68,3 +68,6 @@ If you remove the rail, **the Onboard RGB LED and any plugged-in modules will st
 3. Click **Add** once more to confirm.
 
 <a href="https://esphome.io/components/switch/gpio/" target="_blank" rel="noreferrer nofollow noopener" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> ESPHome GPIO Switch docs</a>
+
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/learning-the-basics/device-builder-tour.md
+++ b/docs/products/ESPHome-Starter-Kit/learning-the-basics/device-builder-tour.md
@@ -81,3 +81,5 @@ Pop them open when something looks off, or just to watch sensor readings come in
 * Bookmark the [official ESPHome documentation](https://esphome.io) for component reference whenever you click a **Docs** link.
 
 <a href="../explaining-esphome/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Back - Explaining ESPHome</a> <a href="../what-is-yaml/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Next - What is YAML?</a>
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/learning-the-basics/explaining-esphome.md
+++ b/docs/products/ESPHome-Starter-Kit/learning-the-basics/explaining-esphome.md
@@ -48,3 +48,6 @@ You get wireless updates, a built-in web page for controlling your device, and d
 The official ESPHome documentation covers every component, configuration option, and advanced topic in detail.
 
 <a href="../device-builder-tour/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Next - Device Builder Tour</a> <a href="https://esphome.io/" target="_blank" rel="noreferrer nofollow noopener" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Visit esphome.io</a>
+
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/learning-the-basics/how-esphome-talks-to-home-assistant.md
+++ b/docs/products/ESPHome-Starter-Kit/learning-the-basics/how-esphome-talks-to-home-assistant.md
@@ -55,3 +55,6 @@ For a single device, the on-device web page is often enough. For anything that t
     For UniFi networks specifically, see our [UniFi mDNS troubleshooting guide](../../../general/troubleshooting/ubiquiti-unifi-mdns-auto-discover-issue/).
 
 <a href="../what-is-secrets-yaml/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Back - What is secrets.yaml?</a> <a href="../../tutorials/connect-to-home-assistant/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Tutorial - Connect to Home Assistant</a>
+
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/learning-the-basics/what-is-secrets-yaml.md
+++ b/docs/products/ESPHome-Starter-Kit/learning-the-basics/what-is-secrets-yaml.md
@@ -38,3 +38,6 @@ Treat secrets.yaml like a password manager entry:
 Ready to put this into practice? The Using Secrets tutorial walks through opening secrets.yaml in the Device Builder, the `!secret` syntax, and what to store for every common case (Wi-Fi, Home Assistant API, OTA, web server auth, MQTT).
 
 <a href="../../tutorials/using-secrets/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Using Secrets tutorial</a>
+
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/learning-the-basics/what-is-yaml.md
+++ b/docs/products/ESPHome-Starter-Kit/learning-the-basics/what-is-yaml.md
@@ -118,3 +118,6 @@ You did not type any of that. The Builder wrote it when you clicked **Add**. Onc
 The official YAML site has the full specification, and the ESPHome docs walk through YAML in the context of ESPHome specifically.
 
 <a href="https://yaml.org/" target="_blank" rel="noreferrer nofollow noopener" class="md-button md-button--primary">YAML official site</a> <a href="https://esphome.io/guides/configuration-types.html" target="_blank" rel="noreferrer nofollow noopener" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> ESPHome YAML guide</a>
+
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/modules/button-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/button-module.md
@@ -128,5 +128,4 @@ Your button is live. Now make it trigger something:
 <a href="/products/ESPHome-Starter-Kit/automations/play-a-tune/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Play a Tune </a>
 <a href="/products/ESPHome-Starter-Kit/automations/press-to-check-climate/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Press to Check Climate </a>
 
-[Join our Discord :simple-discord:](https://link.apolloautomation.com/discord){ .md-button .md-button--discord }
-[Community Forum :material-forum:](https://forum.apolloautomation.com/){ .md-button .md-button--primary }
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/modules/motion-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/motion-module.md
@@ -125,5 +125,4 @@ Your motion sensor is live. Put it to work:
 
 <a href="/products/ESPHome-Starter-Kit/automations/motion-activated-light/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Motion-Activated Light </a>
 
-[Join our Discord :simple-discord:](https://link.apolloautomation.com/discord){ .md-button .md-button--discord }
-[Community Forum :material-forum:](https://forum.apolloautomation.com/){ .md-button .md-button--primary }
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module.md
@@ -138,5 +138,4 @@ Your notification module is ready. Drive it from any of these automations:
 <a href="/products/ESPHome-Starter-Kit/automations/temp-reactive-leds/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Temp-Reactive LEDs </a>
 <a href="/products/ESPHome-Starter-Kit/automations/motion-activated-light/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Motion-Activated Light </a>
 
-[Join our Discord :simple-discord:](https://link.apolloautomation.com/discord){ .md-button .md-button--discord }
-[Community Forum :material-forum:](https://forum.apolloautomation.com/){ .md-button .md-button--primary }
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/modules/temperature-humidity-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/temperature-humidity-module.md
@@ -134,5 +134,4 @@ Your sensor is reporting. Now make it drive something:
 <a href="/products/ESPHome-Starter-Kit/automations/temp-reactive-leds/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Temp-Reactive LEDs </a>
 <a href="/products/ESPHome-Starter-Kit/automations/press-to-check-climate/" class="md-button md-button--primary"> <img src="/assets/esphome-logo.svg" /> Press to Check Climate </a>
 
-[Join our Discord :simple-discord:](https://link.apolloautomation.com/discord){ .md-button .md-button--discord }
-[Community Forum :material-forum:](https://forum.apolloautomation.com/){ .md-button .md-button--primary }
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/setup/first-steps.md
+++ b/docs/products/ESPHome-Starter-Kit/setup/first-steps.md
@@ -220,3 +220,5 @@ Example of the light changing colors below!
 ![](../../../assets/esphome-starter-kit-onboard-rgb-led-light-up.webp)
 
 <a href="../../start-here/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Back - Start Here</a> <a href="../../modules/button-module/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Add More Modules</a> <a href="../../tutorials/connect-to-home-assistant/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Connect to Home Assistant</a>
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/start-here.md
+++ b/docs/products/ESPHome-Starter-Kit/start-here.md
@@ -85,3 +85,5 @@ Each module is connected to the panel by small breakaway tabs. Follow the steps 
 Once you've identified your modules and snapped them off the panel, the next step is to connect the main board to your computer and walk through your first ESPHome configuration.
 
 <a href="../setup/first-steps/" class="md-button md-button--primary">   <img src="/assets/esphome-logo.svg" />   Next - First Steps </a>
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/tutorials/connect-to-home-assistant.md
+++ b/docs/products/ESPHome-Starter-Kit/tutorials/connect-to-home-assistant.md
@@ -48,3 +48,6 @@ Open `secrets.yaml` in Device Builder, copy the `api_encryption_key` value, and 
 Want to understand what just happened under the hood? Read [the Home Assistant integration](../learning-the-basics/how-esphome-talks-to-home-assistant.md).
 
 <a href="../../setup/first-steps/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Back - First Steps</a>
+
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/tutorials/light-effects.md
+++ b/docs/products/ESPHome-Starter-Kit/tutorials/light-effects.md
@@ -62,3 +62,5 @@ If you've already followed [Connect to Home Assistant](/products/ESPHome-Starter
 !!! success "You just edited YAML!"
 
     Every component you add to your device has a set of advanced fields like this one. Pasting a few lines into the right field is all it takes to unlock more behavior, and the YAML pane on the right of the editor will show you exactly what changed.
+
+--8<-- "_snippets/community-help.md"

--- a/docs/products/ESPHome-Starter-Kit/tutorials/using-secrets.md
+++ b/docs/products/ESPHome-Starter-Kit/tutorials/using-secrets.md
@@ -213,3 +213,5 @@ You don't have to include every entry. If a device doesn't use MQTT, leave those
     * Don't share or post the file. Share device YAMLs instead, the `!secret` references are safe.
     * Keep a backup somewhere safe (a password manager works well). If you reinstall ESPHome Device Builder you'll need to recreate it.
     * Rotating a credential is a one-line edit here, then re-flash anything that uses it.
+
+--8<-- "_snippets/community-help.md"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

Adds a consistent **community CTA** to the bottom of every page under the **ESPHome Starter Kit** product. Previously the 4 module pages ended with a bare row of Discord + Community Forum buttons, and the other 17 starter-kit pages had no community CTA at all. Now every page ends with the same friendly note admonition:

> **New to ESPHome? We're here to help.**
>
> Stuck on a step or want to show off what you built? Ask questions and share projects with the Apollo community.
>
> `[Join our Discord]` `[Community Forum]`

The admonition lives in a single shared snippet (`docs/_snippets/community-help.md`) and every starter-kit page references it via `--8<-- "_snippets/community-help.md"`. Edit the snippet, not the 21 pages, when the CTA copy changes.

**Files touched (25 total):**

- **New:** `docs/_snippets/community-help.md` (the snippet)
- **4 module pages** — replace the bare Discord/Forum row with the snippet include (keeps existing "Try it in an automation" automation buttons above): `button-module.md`, `motion-module.md`, `temperature-humidity-module.md`, `rgb-buzzer-module.md`
- **17 other starter-kit pages** — append the snippet include at the bottom: `start-here.md`, `setup/first-steps.md`, 3 `tutorials/`, 5 `automations/`, 6 `learning-the-basics/`, `faq.md`
- **`STYLE_GUIDE.md`** — new section 11 "Community CTA on starter-kit pages" (renumbers "When in doubt" to section 12)
- **`CONTRIBUTING.md`** — one-line bullet under Doc Standards pointing at the new style-guide section
- **`AGENTS.md`** — new bullet under "High-impact rules AI tools get wrong most often" so AI editors don't drop the snippet from new pages

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [ ] Content update (correcting outdated info, adding missing steps, clarifications)
- [ ] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [x] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies — Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [x] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [x] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added standardized community call-to-action messaging across ESPHome Starter Kit pages, including tutorials, modules, learning guides, and FAQ sections.
  * Implemented consistent community help content with links to Discord and Community Forum at the end of relevant documentation pages.
  * Updated documentation standards to ensure uniform community engagement across all starter kit content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->