### PR TITLE
Restructure Bluetooth Proxy guide with product tabs and shared snippets

### DIFF
--- a/docs/_snippets/bluetooth-proxy/air-1.md
+++ b/docs/_snippets/bluetooth-proxy/air-1.md
@@ -1,0 +1,8 @@
+```yaml
+packages:
+  ApolloAutomation.AIR-1:
+    url: https://github.com/ApolloAutomation/AIR-1
+    ref: main
+    files: [Integrations/ESPHome/AIR-1_BLE.yaml]
+    refresh: 1min
+```

--- a/docs/_snippets/bluetooth-proxy/intro.md
+++ b/docs/_snippets/bluetooth-proxy/intro.md
@@ -1,0 +1,1 @@
+This guide shows you how to make your Apollo device act as a "BLE Proxy" which lets Bluetooth devices talk back to home assistant using Apollo devices as the "next hop"!

--- a/docs/_snippets/bluetooth-proxy/method1-finish.md
+++ b/docs/_snippets/bluetooth-proxy/method1-finish.md
@@ -1,0 +1,17 @@
+6\. Paste the code as shown below directly below the yaml you just edited above. Make sure the spaces look the same and there are no red lines under any of the code.
+
+![](/assets/bluetooth-proxy-tutorial-9.png)
+
+7\. Click save then Install in the top right.
+
+![](/assets/bluetooth-proxy-tutorial-11.png)
+
+8\. Click "Wirelessly" and let it finish compiling then installing.
+
+![](/assets/bluetooth-proxy-tutorial-6.png)
+
+9\. When you see this "OTA Successful" it has finished and you can click "Close" in the bottom right.
+
+![](/assets/bluetooth-proxy-tutorial-7.png)
+
+10\. You are finished and your Apollo device is now acting as a Bluetooth Proxy!

--- a/docs/_snippets/bluetooth-proxy/method1-steps.md
+++ b/docs/_snippets/bluetooth-proxy/method1-steps.md
@@ -1,0 +1,13 @@
+1\. Open the Esphome Device Builder.
+
+![](/assets/bluetooth-proxy-tutorial-1.png)
+
+2\. If you do not have it installed, [go here](https://esphome.io/guides/getting_started_hassio.html#installing-esphome-device-compiler "Install Esphome Device Builder.") and then move on to step 3.
+
+3\. Click "Edit" as shown below.
+
+![](/assets/bluetooth-proxy-tutorial-2.png)
+
+4\. Add a \# before the packages line and the line after it as shown in the image below.
+
+![](/assets/bluetooth-proxy-tutorial-10.png)

--- a/docs/_snippets/bluetooth-proxy/method2.md
+++ b/docs/_snippets/bluetooth-proxy/method2.md
@@ -1,0 +1,45 @@
+1\. Open the Esphome Device Builder.
+
+![](/assets/bluetooth-proxy-tutorial-1.png)
+
+2\. If you do not have it installed, [go here](https://esphome.io/guides/getting_started_hassio.html#installing-esphome-device-compiler "Install Esphome Device Builder.") and then move on to step 3.
+
+3\. Click "Edit" as shown below.
+
+![](/assets/bluetooth-proxy-tutorial-2.png)
+
+4\. Copy the code inside the codeblock below.
+
+```yaml
+  power_save_mode: LIGHT
+```
+
+5\. Paste the code as shown below - make sure the spaces look the same and there are no red lines under any of the code.<br>![](/assets/bluetooth-proxy-tutorial-5.png)
+
+6\. Copy the code inside the codeblock below.
+
+```yaml
+bluetooth_proxy:
+  active: true
+esp32_ble_tracker:
+  scan_parameters:
+    active: false
+```
+
+7\. Paste the code on a new line at the very bottom of the file as shown below.
+
+![](/assets/bluetooth-proxy-tutorial-7-1.png)
+
+8\. Click save then Install in the top right.
+
+![](/assets/bluetooth-proxy-tutorial-8.png)
+
+9\. Click "Wirelessly" and let it finish compiling then installing.
+
+![](/assets/bluetooth-proxy-tutorial-6.png)
+
+10\. When you see this "OTA Successful" it has finished and you can click "Close" in the bottom right.
+
+![](/assets/bluetooth-proxy-tutorial-7.png)
+
+11\. You are finished and your Apollo device is now acting as a Bluetooth Proxy!

--- a/docs/_snippets/bluetooth-proxy/msr-1.md
+++ b/docs/_snippets/bluetooth-proxy/msr-1.md
@@ -1,0 +1,8 @@
+```yaml
+packages:
+  ApolloAutomation.MSR-1:
+    url: https://github.com/ApolloAutomation/MSR-1
+    ref: main
+    files: [Integrations/ESPHome/MSR-1_BLE.yaml]
+    refresh: 1min
+```

--- a/docs/_snippets/bluetooth-proxy/msr-2.md
+++ b/docs/_snippets/bluetooth-proxy/msr-2.md
@@ -1,0 +1,8 @@
+```yaml
+packages:
+  ApolloAutomation.MSR-2:
+    url: https://github.com/ApolloAutomation/MSR-2
+    ref: main
+    files: [Integrations/ESPHome/MSR-2_BLE.yaml]
+    refresh: 1min
+```

--- a/docs/_snippets/bluetooth-proxy/mtr-1.md
+++ b/docs/_snippets/bluetooth-proxy/mtr-1.md
@@ -1,0 +1,8 @@
+```yaml
+packages:
+  ApolloAutomation.MTR-1:
+    url: https://github.com/ApolloAutomation/MTR-1
+    ref: main
+    files: [Integrations/ESPHome/MTR-1_BLE.yaml]
+    refresh: 1min
+```

--- a/docs/_snippets/bluetooth-proxy/plt-1.md
+++ b/docs/_snippets/bluetooth-proxy/plt-1.md
@@ -1,0 +1,8 @@
+```yaml
+packages:
+  ApolloAutomation.PLT-1:
+    url: https://github.com/ApolloAutomation/PLT-1
+    ref: main
+    files: [Integrations/ESPHome/PLT-1_BLE.yaml]
+    refresh: 1min
+```

--- a/docs/_snippets/bluetooth-proxy/plt-1b.md
+++ b/docs/_snippets/bluetooth-proxy/plt-1b.md
@@ -1,0 +1,8 @@
+```yaml
+packages:
+  ApolloAutomation.PLT-1:
+    url: https://github.com/ApolloAutomation/PLT-1
+    ref: main
+    files: [Integrations/ESPHome/PLT-1B_BLE.yaml]
+    refresh: 1min
+```

--- a/docs/_snippets/bluetooth-proxy/temp-1.md
+++ b/docs/_snippets/bluetooth-proxy/temp-1.md
@@ -1,0 +1,8 @@
+```yaml
+packages:
+  ApolloAutomation.TEMP-1:
+    url: https://github.com/ApolloAutomation/TEMP-1
+    ref: main
+    files: [Integrations/ESPHome/TEMP-1_BLE_R2.yaml]
+    refresh: 1min
+```

--- a/docs/_snippets/bluetooth-proxy/temp-1b.md
+++ b/docs/_snippets/bluetooth-proxy/temp-1b.md
@@ -1,0 +1,8 @@
+```yaml
+packages:
+  ApolloAutomation.TEMP-1:
+    url: https://github.com/ApolloAutomation/TEMP-1
+    ref: main
+    files: [Integrations/ESPHome/TEMP-1B_BLE_R2.yaml]
+    refresh: 1min
+```

--- a/docs/products/air1/additional-info/bluetooth-proxy.md
+++ b/docs/products/air1/additional-info/bluetooth-proxy.md
@@ -1,0 +1,23 @@
+﻿---
+title: AIR-1 Bluetooth Proxy
+description: Tutorial for how to turn your AIR-1 into a BLE proxy!
+---
+# AIR-1 Bluetooth Proxy
+
+--8<-- "_snippets/bluetooth-proxy/intro.md"
+
+### Method 1: Switch to AIR-1\_BLE.yaml fork
+
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+
+--8<-- "_snippets/bluetooth-proxy/air-1.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"
+
+---
+
+### Method 2: Manually enter the BLE proxy yaml
+
+--8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/general/setup/bluetooth-proxy.md
+++ b/docs/products/general/setup/bluetooth-proxy.md
@@ -1,106 +1,57 @@
----
+﻿---
 title: Bluetooth Proxy Setup
 description: Tutorial for how to turn your Apollo device into a BLE proxy!
 ---
 # Bluetooth Proxy
 
-This guide shows you how to make your Apollo device act as a "BLE Proxy" which lets Bluetooth devices talk back to home assistant using Apollo devices as the "next hop"!
+--8<-- "_snippets/bluetooth-proxy/intro.md"
 
 ### Method 1: Switch to \_BLE.yaml fork
 
-1\. Open the Esphome Device Builder.
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
 
-![](/assets/bluetooth-proxy-tutorial-1.png)
+5\. Select your product below, copy the code, and paste it directly below the two lines you just commented out.
 
-2\. If you do not have it installed, [go here](https://esphome.io/guides/getting_started_hassio.html#installing-esphome-device-compiler "Install Esphome Device Builder.") and then move on to step 3.
+=== "AIR-1"
 
-3\. Click "Edit" as shown below.
+    --8<-- "_snippets/bluetooth-proxy/air-1.md"
 
-![](/assets/bluetooth-proxy-tutorial-2.png)
+=== "MSR-1"
 
-4\. Add a \# before the packages line and the line after it as shown in the image below.
+    --8<-- "_snippets/bluetooth-proxy/msr-1.md"
 
-![](/assets/bluetooth-proxy-tutorial-10.png)
+=== "MSR-2"
 
-5\. Copy the code inside the codeblock below.
+    --8<-- "_snippets/bluetooth-proxy/msr-2.md"
 
-```yaml
-packages:
-  ApolloAutomation.MTR-1: # name of package/project
-    url: https://github.com/ApolloAutomation/MTR-1 # url of the repository
-    ref: main # branch, tag or commit SHA
-    files: [Integrations/ESPHome/MTR-1_BLE.yaml] # Path to config from base repo URL
-    refresh: 1min # how often to sync updates from the remote url
-```
+=== "MTR-1"
 
-!!! success "Replace MTR-1 in all three areas of the code you copied above with MSR-2, AIR-1 etc."
+    --8<-- "_snippets/bluetooth-proxy/mtr-1.md"
 
-    Scroll down and follow method \#2, or manually replace "MTR-1" with "MSR-2", "AIR-1", or whichever sensor you're using in each instance.
+=== "PLT-1 / PLT-1B"
 
-6\. Paste the code as shown below directly below the yaml you just edited above. Make sure the spaces look the same and there are no red lines under any of the code.
+    **PLT-1:**
 
-![](/assets/bluetooth-proxy-tutorial-9.png)
+    --8<-- "_snippets/bluetooth-proxy/plt-1.md"
 
-7\. Click save then Install in the top right.
+    **PLT-1B:**
 
-![](/assets/bluetooth-proxy-tutorial-11.png)
+    --8<-- "_snippets/bluetooth-proxy/plt-1b.md"
 
-8\. Click "Wirelessly" and let it finish compiling then installing.
+=== "TEMP-1 / TEMP-1B"
 
-![](/assets/bluetooth-proxy-tutorial-6.png)
+    **TEMP-1:**
 
-9\. When you see this "OTA Successful" it has finished and you can click "Close" in the bottom right.
+    --8<-- "_snippets/bluetooth-proxy/temp-1.md"
 
-![](/assets/bluetooth-proxy-tutorial-7.png)
+    **TEMP-1B:**
 
-10\. You are finished and your Apollo device is now acting as a Bluetooth Proxy!
+    --8<-- "_snippets/bluetooth-proxy/temp-1b.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"
 
 ---
 
 ### Method 2: Manually enter the BLE proxy yaml
 
-1\. Open the Esphome Device Builder.
-
-![](/assets/bluetooth-proxy-tutorial-1.png)
-
-2\. If you do not have it installed, [go here](https://esphome.io/guides/getting_started_hassio.html#installing-esphome-device-compiler "Install Esphome Device Builder.") and then move on to step 3.
-
-3\. Click "Edit" as shown below.
-
-![](/assets/bluetooth-proxy-tutorial-2.png)
-
-4\. Copy the code inside the codeblock below.
-
-```yaml
-  power_save_mode: LIGHT
-```
-
-5\. Paste the code as shown below - make sure the spaces look the same and there are no red lines under any of the code.<br>![](/assets/bluetooth-proxy-tutorial-5.png)
-
-6\. Copy the code inside the codeblock below.
-
-```yaml
-bluetooth_proxy:
-  active: true
-esp32_ble_tracker:
-  scan_parameters:
-    active: false
-```
-
-7\. Paste the code on a new line at the very bottom of the file as shown below.
-
-![](/assets/bluetooth-proxy-tutorial-7-1.png)
-
-8\. Click save then Install in the top right.
-
-![](/assets/bluetooth-proxy-tutorial-8.png)
-
-8\. Click "Wirelessly" and let it finish compiling then installing.
-
-![](/assets/bluetooth-proxy-tutorial-6.png)
-
-9\. When you see this "OTA Successful" it has finished and you can click "Close" in the bottom right.
-
-![](/assets/bluetooth-proxy-tutorial-7.png)
-
-10\. You are finished and your Apollo device is now acting as a Bluetooth Proxy!
+--8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/msr1/additional-info/bluetooth-proxy.md
+++ b/docs/products/msr1/additional-info/bluetooth-proxy.md
@@ -1,0 +1,23 @@
+﻿---
+title: MSR-1 Bluetooth Proxy
+description: Tutorial for how to turn your MSR-1 into a BLE proxy!
+---
+# MSR-1 Bluetooth Proxy
+
+--8<-- "_snippets/bluetooth-proxy/intro.md"
+
+### Method 1: Switch to MSR-1\_BLE.yaml fork
+
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+
+--8<-- "_snippets/bluetooth-proxy/msr-1.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"
+
+---
+
+### Method 2: Manually enter the BLE proxy yaml
+
+--8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/msr2/additional-info/bluetooth-proxy.md
+++ b/docs/products/msr2/additional-info/bluetooth-proxy.md
@@ -1,0 +1,23 @@
+﻿---
+title: MSR-2 Bluetooth Proxy
+description: Tutorial for how to turn your MSR-2 into a BLE proxy!
+---
+# MSR-2 Bluetooth Proxy
+
+--8<-- "_snippets/bluetooth-proxy/intro.md"
+
+### Method 1: Switch to MSR-2\_BLE.yaml fork
+
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+
+--8<-- "_snippets/bluetooth-proxy/msr-2.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"
+
+---
+
+### Method 2: Manually enter the BLE proxy yaml
+
+--8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/mtr1/additional-info/bluetooth-proxy.md
+++ b/docs/products/mtr1/additional-info/bluetooth-proxy.md
@@ -1,0 +1,23 @@
+﻿---
+title: MTR-1 Bluetooth Proxy
+description: Tutorial for how to turn your MTR-1 into a BLE proxy!
+---
+# MTR-1 Bluetooth Proxy
+
+--8<-- "_snippets/bluetooth-proxy/intro.md"
+
+### Method 1: Switch to MTR-1\_BLE.yaml fork
+
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+
+--8<-- "_snippets/bluetooth-proxy/mtr-1.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"
+
+---
+
+### Method 2: Manually enter the BLE proxy yaml
+
+--8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/plt1/additional-info/bluetooth-proxy.md
+++ b/docs/products/plt1/additional-info/bluetooth-proxy.md
@@ -1,0 +1,23 @@
+﻿---
+title: PLT-1 Bluetooth Proxy
+description: Tutorial for how to turn your PLT-1 into a BLE proxy!
+---
+# PLT-1 Bluetooth Proxy
+
+--8<-- "_snippets/bluetooth-proxy/intro.md"
+
+### Method 1: Switch to PLT-1\_BLE.yaml fork
+
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+
+--8<-- "_snippets/bluetooth-proxy/plt-1.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"
+
+---
+
+### Method 2: Manually enter the BLE proxy yaml
+
+--8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/plt1b/additional-info/bluetooth-proxy.md
+++ b/docs/products/plt1b/additional-info/bluetooth-proxy.md
@@ -1,0 +1,23 @@
+﻿---
+title: PLT-1B Bluetooth Proxy
+description: Tutorial for how to turn your PLT-1B into a BLE proxy!
+---
+# PLT-1B Bluetooth Proxy
+
+--8<-- "_snippets/bluetooth-proxy/intro.md"
+
+### Method 1: Switch to PLT-1B\_BLE.yaml fork
+
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+
+--8<-- "_snippets/bluetooth-proxy/plt-1b.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"
+
+---
+
+### Method 2: Manually enter the BLE proxy yaml
+
+--8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/temp1/additional-info/bluetooth-proxy.md
+++ b/docs/products/temp1/additional-info/bluetooth-proxy.md
@@ -1,0 +1,23 @@
+﻿---
+title: TEMP-1 Bluetooth Proxy
+description: Tutorial for how to turn your TEMP-1 into a BLE proxy!
+---
+# TEMP-1 Bluetooth Proxy
+
+--8<-- "_snippets/bluetooth-proxy/intro.md"
+
+### Method 1: Switch to TEMP-1\_BLE.yaml fork
+
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+
+--8<-- "_snippets/bluetooth-proxy/temp-1.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"
+
+---
+
+### Method 2: Manually enter the BLE proxy yaml
+
+--8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/temp1b/additional-info/bluetooth-proxy.md
+++ b/docs/products/temp1b/additional-info/bluetooth-proxy.md
@@ -1,0 +1,23 @@
+﻿---
+title: TEMP-1B Bluetooth Proxy
+description: Tutorial for how to turn your TEMP-1B into a BLE proxy!
+---
+# TEMP-1B Bluetooth Proxy
+
+--8<-- "_snippets/bluetooth-proxy/intro.md"
+
+### Method 1: Switch to TEMP-1B\_BLE.yaml fork
+
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+
+--8<-- "_snippets/bluetooth-proxy/temp-1b.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"
+
+---
+
+### Method 2: Manually enter the BLE proxy yaml
+
+--8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -227,6 +227,7 @@ nav:
               - Additional Info:
                 - General Tips: products/msr2/setup/msr2-general-tips.md
                 - Sensor Definitions: products/msr2/setup/msr2-sensor-definitions.md
+                - Bluetooth Proxy: products/msr2/additional-info/bluetooth-proxy.md
               - Addons:
                 - Articulating Stand: products/msr2/addons/adding-articulating-stand-to-msr-2.md
                 - CO<sub>2</sub> Addon: products/msr2/addons/adding-co2-to-msr-2.md
@@ -254,6 +255,7 @@ nav:
               - Additional Info:
                 - General Tips: products/mtr1/setup/general-tips.md
                 - Sensor Definitions: products/mtr1/setup/sensor-definitions.md
+                - Bluetooth Proxy: products/mtr1/additional-info/bluetooth-proxy.md
               - Addons:
                 - Articulating Stand: products/mtr1/addons/adding-articulating-stand-to-mtr-1.md
                 - CO<sub>2</sub> Addon: products/mtr1/addons/adding-co2-to-mtr-1.md
@@ -304,6 +306,7 @@ nav:
                   - HLK Radar Tool App: products/msr1/setup/zones-hlk.md
                   - mmWave Tuning Videos: products/msr1/setup/mmwave-videos.md
                 - Exposed GPIO: products/msr1/additional-info/exposed-gpio.md
+                - Bluetooth Proxy: products/msr1/additional-info/bluetooth-proxy.md
               - Addons: products/msr1/addons/adding-co2-to-msr-1.md
               - Examples:
                 - MSR-1 Dashboards: products/msr1/examples/msr1-dashboards.md
@@ -323,6 +326,7 @@ nav:
                 - General Tips: products/air1/setup/general-tips.md
                 - Sensor Definitions: products/air1/setup/sensor-definitions.md
                 - Prevent Sleep: products/air1/additional-info/prevent-sleep.md
+                - Bluetooth Proxy: products/air1/additional-info/bluetooth-proxy.md
               - Addons:
                 - CO<sub>2</sub> Addon: products/air1/addons/adding-co2-to-air-1.md
                 - MiCS Addon: products/air1/addons/adding-the-mics-4514-gas-sensor-to-the-air-1.md
@@ -348,6 +352,7 @@ nav:
                 - How To Wake Up Your Sensor: products/temp1/battery-sensors/wake-up-battery-sensor.md
                 - Keep Your Sensor Awake With HA Helper: products/temp1/battery-sensors/awake-ha-helper.md
                 - Sensor Connection Check: products/temp1/battery-sensors/sensor-connection-check.md
+                - Bluetooth Proxy: products/temp1/additional-info/bluetooth-proxy.md
               - Addons:
                 - Magnetic Mount: products/temp1/addons/magnetic-mount.md
                 - Temp Probe: products/temp1/addons/temp-probe.md
@@ -375,6 +380,7 @@ nav:
                 - Keep Your Sensor Awake With HA Helper: products/temp1b/battery-sensors/awake-ha-helper.md
                 - Insert Battery: products/temp1b/setup/insert-battery.md
                 - Sensor Connection Check: products/temp1b/battery-sensors/sensor-connection-check.md
+                - Bluetooth Proxy: products/temp1b/additional-info/bluetooth-proxy.md
               - Addons:
                 - Magnetic Mount: products/temp1b/addons/magnetic-mount.md
                 - Temp Probe: products/temp1b/addons/temp-probe.md
@@ -400,6 +406,7 @@ nav:
                 - Sensor Definitions: products/plt1/setup/plt1-sensor-definitions.md
                 - Calibrating Soil Moisture: products/plt1/calibrate-plt1.md
                 - Prevent Sleep: products/plt1/additional-info/prevent-sleep.md
+                - Bluetooth Proxy: products/plt1/additional-info/bluetooth-proxy.md
               - Examples:
                 - Flower Card: products/plt1/examples/flower-card.md
                 - Blueprint: products/plt1/examples/blueprint.md
@@ -422,6 +429,7 @@ nav:
                 - Keep Your Sensor Awake With HA Helper: products/plt1b/battery-sensors/awake-ha-helper.md
                 - Insert Battery: products/plt1b/additional-info/insert-battery.md
                 - Sensor Connection Check: products/plt1b/battery-sensors/sensor-connection-check.md
+                - Bluetooth Proxy: products/plt1b/additional-info/bluetooth-proxy.md
               - Examples:
                 - Flower Card: products/plt1b/examples/flower-card.md
                 - Blueprint: products/plt1b/examples/blueprint.md


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

Restructures the Bluetooth Proxy guide so the package codeblocks are maintained in one place and surfaced per product:

- The general Bluetooth Proxy page now uses per-product content tabs for the Method 1 package code, matching the Switch to Beta page.
- Adds a Bluetooth Proxy page under Additional Info for every product that ships a `_BLE.yaml` in its firmware repo: AIR-1, MSR-1, MSR-2, MTR-1, PLT-1, PLT-1B, TEMP-1, and TEMP-1B. Each page shows only that product's code.
- All pages pull the shared instructions and per-product package codeblocks from snippets in `docs/_snippets/bluetooth-proxy/`, so updating a codeblock once updates the tabbed page and the product page together.
- R-PRO-1, PUMP-1, and BTN-1 are not included because their repos have no `_BLE.yaml`.
- TEMP-1/TEMP-1B use the `_BLE_R2.yaml` variants, following the R2 convention on the Switch to Beta page.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [ ] Content update (correcting outdated info, adding missing steps, clarifications)
- [x] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies - Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [x] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Bluetooth Proxy setup guides for Apollo devices (AIR-1, MSR-1, MSR-2, MTR-1, PLT-1, PLT-1B, TEMP-1, TEMP-1B).
  * Documented two configuration methods for enabling BLE proxy functionality.
  * Updated site navigation to surface Bluetooth Proxy documentation across product pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->