### PR TITLE
Move Bluetooth Proxy product tabs to top level and cover all products

### DIFF
--- a/docs/_snippets/bluetooth-proxy/method1-air-1.md
+++ b/docs/_snippets/bluetooth-proxy/method1-air-1.md
@@ -1,0 +1,7 @@
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below.
+
+--8<-- "_snippets/bluetooth-proxy/air-1.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"

--- a/docs/_snippets/bluetooth-proxy/method1-msr-1.md
+++ b/docs/_snippets/bluetooth-proxy/method1-msr-1.md
@@ -1,0 +1,7 @@
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below.
+
+--8<-- "_snippets/bluetooth-proxy/msr-1.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"

--- a/docs/_snippets/bluetooth-proxy/method1-msr-2.md
+++ b/docs/_snippets/bluetooth-proxy/method1-msr-2.md
@@ -1,0 +1,7 @@
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below.
+
+--8<-- "_snippets/bluetooth-proxy/msr-2.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"

--- a/docs/_snippets/bluetooth-proxy/method1-mtr-1.md
+++ b/docs/_snippets/bluetooth-proxy/method1-mtr-1.md
@@ -1,0 +1,7 @@
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below.
+
+--8<-- "_snippets/bluetooth-proxy/mtr-1.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"

--- a/docs/_snippets/bluetooth-proxy/method1-plt-1.md
+++ b/docs/_snippets/bluetooth-proxy/method1-plt-1.md
@@ -1,0 +1,7 @@
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below.
+
+--8<-- "_snippets/bluetooth-proxy/plt-1.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"

--- a/docs/_snippets/bluetooth-proxy/method1-plt-1b.md
+++ b/docs/_snippets/bluetooth-proxy/method1-plt-1b.md
@@ -1,0 +1,7 @@
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below.
+
+--8<-- "_snippets/bluetooth-proxy/plt-1b.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"

--- a/docs/_snippets/bluetooth-proxy/method1-temp-1.md
+++ b/docs/_snippets/bluetooth-proxy/method1-temp-1.md
@@ -1,0 +1,7 @@
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below.
+
+--8<-- "_snippets/bluetooth-proxy/temp-1.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"

--- a/docs/_snippets/bluetooth-proxy/method1-temp-1b.md
+++ b/docs/_snippets/bluetooth-proxy/method1-temp-1b.md
@@ -1,0 +1,7 @@
+--8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+
+5\. Copy the code inside the codeblock below.
+
+--8<-- "_snippets/bluetooth-proxy/temp-1b.md"
+
+--8<-- "_snippets/bluetooth-proxy/method1-finish.md"

--- a/docs/_snippets/bluetooth-proxy/no-ble-fork-page.md
+++ b/docs/_snippets/bluetooth-proxy/no-ble-fork-page.md
@@ -1,0 +1,3 @@
+!!! info "This product does not have a prebuilt \_BLE.yaml firmware"
+
+    This product is set up as a Bluetooth Proxy by adding the BLE proxy yaml to your existing config by hand. Follow the steps below.

--- a/docs/_snippets/bluetooth-proxy/no-ble-fork-tab.md
+++ b/docs/_snippets/bluetooth-proxy/no-ble-fork-tab.md
@@ -1,0 +1,3 @@
+!!! info "This product needs Method 2"
+
+    This product does not have a prebuilt \_BLE.yaml firmware, so Method 1 does not apply. Scroll down and follow **Method 2** to add the BLE proxy yaml to your existing config by hand.

--- a/docs/products/air1/additional-info/bluetooth-proxy.md
+++ b/docs/products/air1/additional-info/bluetooth-proxy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: AIR-1 Bluetooth Proxy
 description: Tutorial for how to turn your AIR-1 into a BLE proxy!
 ---
@@ -6,18 +6,12 @@ description: Tutorial for how to turn your AIR-1 into a BLE proxy!
 
 --8<-- "_snippets/bluetooth-proxy/intro.md"
 
-### Method 1: Switch to AIR-1\_BLE.yaml fork
+Select a method below. Method 1 switches your AIR-1 to the prebuilt AIR-1_BLE.yaml firmware. Method 2 adds the BLE proxy yaml to your existing config by hand.
 
---8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+=== "Method 1: AIR-1_BLE.yaml firmware"
 
-5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+    --8<-- "_snippets/bluetooth-proxy/method1-air-1.md"
 
---8<-- "_snippets/bluetooth-proxy/air-1.md"
+=== "Method 2: Manually enter the BLE proxy yaml"
 
---8<-- "_snippets/bluetooth-proxy/method1-finish.md"
-
----
-
-### Method 2: Manually enter the BLE proxy yaml
-
---8<-- "_snippets/bluetooth-proxy/method2.md"
+    --8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/btn1/additional-info/bluetooth-proxy.md
+++ b/docs/products/btn1/additional-info/bluetooth-proxy.md
@@ -1,0 +1,15 @@
+---
+title: BTN-1 Bluetooth Proxy
+description: Tutorial for how to turn your BTN-1 into a BLE proxy!
+---
+# BTN-1 Bluetooth Proxy
+
+--8<-- "_snippets/bluetooth-proxy/intro.md"
+
+!!! info "This product does not have a prebuilt \_BLE.yaml firmware"
+
+    This product is set up as a Bluetooth Proxy by adding the BLE proxy yaml to your existing config by hand. Follow the steps below.
+
+    Sleep must be disabled for the BTN-1 to work as a Bluetooth Proxy. See the [Prevent Sleep guide](https://wiki.apolloautomation.com/products/btn1/additional-info/prevent-sleep/).
+
+--8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/general/setup/bluetooth-proxy.md
+++ b/docs/products/general/setup/bluetooth-proxy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Bluetooth Proxy Setup
 description: Tutorial for how to turn your Apollo device into a BLE proxy!
 ---
@@ -6,52 +6,62 @@ description: Tutorial for how to turn your Apollo device into a BLE proxy!
 
 --8<-- "_snippets/bluetooth-proxy/intro.md"
 
-### Method 1: Switch to \_BLE.yaml fork
+### Method 1: Switch to \_BLE.yaml firmware
 
---8<-- "_snippets/bluetooth-proxy/method1-steps.md"
-
-5\. Select your product below, copy the code, and paste it directly below the two lines you just commented out.
+Select your product below to see the full walkthrough.
 
 === "AIR-1"
 
-    --8<-- "_snippets/bluetooth-proxy/air-1.md"
+    --8<-- "_snippets/bluetooth-proxy/method1-air-1.md"
 
 === "MSR-1"
 
-    --8<-- "_snippets/bluetooth-proxy/msr-1.md"
+    --8<-- "_snippets/bluetooth-proxy/method1-msr-1.md"
 
 === "MSR-2"
 
-    --8<-- "_snippets/bluetooth-proxy/msr-2.md"
+    --8<-- "_snippets/bluetooth-proxy/method1-msr-2.md"
 
 === "MTR-1"
 
-    --8<-- "_snippets/bluetooth-proxy/mtr-1.md"
+    --8<-- "_snippets/bluetooth-proxy/method1-mtr-1.md"
 
-=== "PLT-1 / PLT-1B"
+=== "R-PRO-1"
 
-    **PLT-1:**
+    --8<-- "_snippets/bluetooth-proxy/no-ble-fork-tab.md"
 
-    --8<-- "_snippets/bluetooth-proxy/plt-1.md"
+=== "PUMP-1"
 
-    **PLT-1B:**
+    --8<-- "_snippets/bluetooth-proxy/no-ble-fork-tab.md"
 
-    --8<-- "_snippets/bluetooth-proxy/plt-1b.md"
+=== "PLT-1"
 
-=== "TEMP-1 / TEMP-1B"
+    --8<-- "_snippets/bluetooth-proxy/method1-plt-1.md"
 
-    **TEMP-1:**
+=== "PLT-1B"
 
-    --8<-- "_snippets/bluetooth-proxy/temp-1.md"
+    --8<-- "_snippets/bluetooth-proxy/method1-plt-1b.md"
 
-    **TEMP-1B:**
+=== "TEMP-1"
 
-    --8<-- "_snippets/bluetooth-proxy/temp-1b.md"
+    --8<-- "_snippets/bluetooth-proxy/method1-temp-1.md"
 
---8<-- "_snippets/bluetooth-proxy/method1-finish.md"
+=== "TEMP-1B"
+
+    --8<-- "_snippets/bluetooth-proxy/method1-temp-1b.md"
+
+=== "BTN-1"
+
+    !!! info "This product needs Method 2"
+
+        This product does not have a prebuilt \_BLE.yaml firmware, so Method 1 does not apply. Scroll down and follow **Method 2** to add the BLE proxy yaml to your existing config by hand.
+
+        Sleep must be disabled for the BTN-1 to work as a Bluetooth Proxy. See the [Prevent Sleep guide](https://wiki.apolloautomation.com/products/btn1/additional-info/prevent-sleep/).
 
 ---
 
 ### Method 2: Manually enter the BLE proxy yaml
+
+This method works the same on every product.
 
 --8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/msr1/additional-info/bluetooth-proxy.md
+++ b/docs/products/msr1/additional-info/bluetooth-proxy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: MSR-1 Bluetooth Proxy
 description: Tutorial for how to turn your MSR-1 into a BLE proxy!
 ---
@@ -6,18 +6,12 @@ description: Tutorial for how to turn your MSR-1 into a BLE proxy!
 
 --8<-- "_snippets/bluetooth-proxy/intro.md"
 
-### Method 1: Switch to MSR-1\_BLE.yaml fork
+Select a method below. Method 1 switches your MSR-1 to the prebuilt MSR-1_BLE.yaml firmware. Method 2 adds the BLE proxy yaml to your existing config by hand.
 
---8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+=== "Method 1: MSR-1_BLE.yaml firmware"
 
-5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+    --8<-- "_snippets/bluetooth-proxy/method1-msr-1.md"
 
---8<-- "_snippets/bluetooth-proxy/msr-1.md"
+=== "Method 2: Manually enter the BLE proxy yaml"
 
---8<-- "_snippets/bluetooth-proxy/method1-finish.md"
-
----
-
-### Method 2: Manually enter the BLE proxy yaml
-
---8<-- "_snippets/bluetooth-proxy/method2.md"
+    --8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/msr2/additional-info/bluetooth-proxy.md
+++ b/docs/products/msr2/additional-info/bluetooth-proxy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: MSR-2 Bluetooth Proxy
 description: Tutorial for how to turn your MSR-2 into a BLE proxy!
 ---
@@ -6,18 +6,12 @@ description: Tutorial for how to turn your MSR-2 into a BLE proxy!
 
 --8<-- "_snippets/bluetooth-proxy/intro.md"
 
-### Method 1: Switch to MSR-2\_BLE.yaml fork
+Select a method below. Method 1 switches your MSR-2 to the prebuilt MSR-2_BLE.yaml firmware. Method 2 adds the BLE proxy yaml to your existing config by hand.
 
---8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+=== "Method 1: MSR-2_BLE.yaml firmware"
 
-5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+    --8<-- "_snippets/bluetooth-proxy/method1-msr-2.md"
 
---8<-- "_snippets/bluetooth-proxy/msr-2.md"
+=== "Method 2: Manually enter the BLE proxy yaml"
 
---8<-- "_snippets/bluetooth-proxy/method1-finish.md"
-
----
-
-### Method 2: Manually enter the BLE proxy yaml
-
---8<-- "_snippets/bluetooth-proxy/method2.md"
+    --8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/mtr1/additional-info/bluetooth-proxy.md
+++ b/docs/products/mtr1/additional-info/bluetooth-proxy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: MTR-1 Bluetooth Proxy
 description: Tutorial for how to turn your MTR-1 into a BLE proxy!
 ---
@@ -6,18 +6,12 @@ description: Tutorial for how to turn your MTR-1 into a BLE proxy!
 
 --8<-- "_snippets/bluetooth-proxy/intro.md"
 
-### Method 1: Switch to MTR-1\_BLE.yaml fork
+Select a method below. Method 1 switches your MTR-1 to the prebuilt MTR-1_BLE.yaml firmware. Method 2 adds the BLE proxy yaml to your existing config by hand.
 
---8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+=== "Method 1: MTR-1_BLE.yaml firmware"
 
-5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+    --8<-- "_snippets/bluetooth-proxy/method1-mtr-1.md"
 
---8<-- "_snippets/bluetooth-proxy/mtr-1.md"
+=== "Method 2: Manually enter the BLE proxy yaml"
 
---8<-- "_snippets/bluetooth-proxy/method1-finish.md"
-
----
-
-### Method 2: Manually enter the BLE proxy yaml
-
---8<-- "_snippets/bluetooth-proxy/method2.md"
+    --8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/plt1/additional-info/bluetooth-proxy.md
+++ b/docs/products/plt1/additional-info/bluetooth-proxy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PLT-1 Bluetooth Proxy
 description: Tutorial for how to turn your PLT-1 into a BLE proxy!
 ---
@@ -6,18 +6,12 @@ description: Tutorial for how to turn your PLT-1 into a BLE proxy!
 
 --8<-- "_snippets/bluetooth-proxy/intro.md"
 
-### Method 1: Switch to PLT-1\_BLE.yaml fork
+Select a method below. Method 1 switches your PLT-1 to the prebuilt PLT-1_BLE.yaml firmware. Method 2 adds the BLE proxy yaml to your existing config by hand.
 
---8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+=== "Method 1: PLT-1_BLE.yaml firmware"
 
-5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+    --8<-- "_snippets/bluetooth-proxy/method1-plt-1.md"
 
---8<-- "_snippets/bluetooth-proxy/plt-1.md"
+=== "Method 2: Manually enter the BLE proxy yaml"
 
---8<-- "_snippets/bluetooth-proxy/method1-finish.md"
-
----
-
-### Method 2: Manually enter the BLE proxy yaml
-
---8<-- "_snippets/bluetooth-proxy/method2.md"
+    --8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/plt1b/additional-info/bluetooth-proxy.md
+++ b/docs/products/plt1b/additional-info/bluetooth-proxy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: PLT-1B Bluetooth Proxy
 description: Tutorial for how to turn your PLT-1B into a BLE proxy!
 ---
@@ -6,18 +6,12 @@ description: Tutorial for how to turn your PLT-1B into a BLE proxy!
 
 --8<-- "_snippets/bluetooth-proxy/intro.md"
 
-### Method 1: Switch to PLT-1B\_BLE.yaml fork
+Select a method below. Method 1 switches your PLT-1B to the prebuilt PLT-1B_BLE.yaml firmware. Method 2 adds the BLE proxy yaml to your existing config by hand.
 
---8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+=== "Method 1: PLT-1B_BLE.yaml firmware"
 
-5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+    --8<-- "_snippets/bluetooth-proxy/method1-plt-1b.md"
 
---8<-- "_snippets/bluetooth-proxy/plt-1b.md"
+=== "Method 2: Manually enter the BLE proxy yaml"
 
---8<-- "_snippets/bluetooth-proxy/method1-finish.md"
-
----
-
-### Method 2: Manually enter the BLE proxy yaml
-
---8<-- "_snippets/bluetooth-proxy/method2.md"
+    --8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/pump1/additional-info/bluetooth-proxy.md
+++ b/docs/products/pump1/additional-info/bluetooth-proxy.md
@@ -1,0 +1,11 @@
+---
+title: PUMP-1 Bluetooth Proxy
+description: Tutorial for how to turn your PUMP-1 into a BLE proxy!
+---
+# PUMP-1 Bluetooth Proxy
+
+--8<-- "_snippets/bluetooth-proxy/intro.md"
+
+--8<-- "_snippets/bluetooth-proxy/no-ble-fork-page.md"
+
+--8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/rpro1/additional-info/bluetooth-proxy.md
+++ b/docs/products/rpro1/additional-info/bluetooth-proxy.md
@@ -1,0 +1,11 @@
+---
+title: R-PRO-1 Bluetooth Proxy
+description: Tutorial for how to turn your R-PRO-1 into a BLE proxy!
+---
+# R-PRO-1 Bluetooth Proxy
+
+--8<-- "_snippets/bluetooth-proxy/intro.md"
+
+--8<-- "_snippets/bluetooth-proxy/no-ble-fork-page.md"
+
+--8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/temp1/additional-info/bluetooth-proxy.md
+++ b/docs/products/temp1/additional-info/bluetooth-proxy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: TEMP-1 Bluetooth Proxy
 description: Tutorial for how to turn your TEMP-1 into a BLE proxy!
 ---
@@ -6,18 +6,12 @@ description: Tutorial for how to turn your TEMP-1 into a BLE proxy!
 
 --8<-- "_snippets/bluetooth-proxy/intro.md"
 
-### Method 1: Switch to TEMP-1\_BLE.yaml fork
+Select a method below. Method 1 switches your TEMP-1 to the prebuilt TEMP-1_BLE.yaml firmware. Method 2 adds the BLE proxy yaml to your existing config by hand.
 
---8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+=== "Method 1: TEMP-1_BLE.yaml firmware"
 
-5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+    --8<-- "_snippets/bluetooth-proxy/method1-temp-1.md"
 
---8<-- "_snippets/bluetooth-proxy/temp-1.md"
+=== "Method 2: Manually enter the BLE proxy yaml"
 
---8<-- "_snippets/bluetooth-proxy/method1-finish.md"
-
----
-
-### Method 2: Manually enter the BLE proxy yaml
-
---8<-- "_snippets/bluetooth-proxy/method2.md"
+    --8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/docs/products/temp1b/additional-info/bluetooth-proxy.md
+++ b/docs/products/temp1b/additional-info/bluetooth-proxy.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: TEMP-1B Bluetooth Proxy
 description: Tutorial for how to turn your TEMP-1B into a BLE proxy!
 ---
@@ -6,18 +6,12 @@ description: Tutorial for how to turn your TEMP-1B into a BLE proxy!
 
 --8<-- "_snippets/bluetooth-proxy/intro.md"
 
-### Method 1: Switch to TEMP-1B\_BLE.yaml fork
+Select a method below. Method 1 switches your TEMP-1B to the prebuilt TEMP-1B_BLE.yaml firmware. Method 2 adds the BLE proxy yaml to your existing config by hand.
 
---8<-- "_snippets/bluetooth-proxy/method1-steps.md"
+=== "Method 1: TEMP-1B_BLE.yaml firmware"
 
-5\. Copy the code inside the codeblock below and paste it directly below the two lines you just commented out.
+    --8<-- "_snippets/bluetooth-proxy/method1-temp-1b.md"
 
---8<-- "_snippets/bluetooth-proxy/temp-1b.md"
+=== "Method 2: Manually enter the BLE proxy yaml"
 
---8<-- "_snippets/bluetooth-proxy/method1-finish.md"
-
----
-
-### Method 2: Manually enter the BLE proxy yaml
-
---8<-- "_snippets/bluetooth-proxy/method2.md"
+    --8<-- "_snippets/bluetooth-proxy/method2.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -283,6 +283,7 @@ nav:
                 - Switch Firmware: products/rpro1/setup/rpro1-switch-firmware.md
                 - General Tips: products/rpro1/setup/rpro1-general-tips.md
                 - Sensor Definitions: products/rpro1/setup/rpro1-sensor-definitions.md
+                - Bluetooth Proxy: products/rpro1/additional-info/bluetooth-proxy.md
               - Addons:
                 - CO<sub>2</sub> Addon: products/rpro1/addons/adding-co2-to-r-pro-1.md
                 - 1-Gang Box Mount: products/rpro1/addons/attaching-gang-box-mount-to-r-pro-1.md
@@ -491,6 +492,7 @@ nav:
           - Additional Info:
             - General Tips: products/pump1/setup/pump1-general-tips.md
             - Sensor Definitions: products/pump1/setup/pump1-sensor-definitions.md
+            - Bluetooth Proxy: products/pump1/additional-info/bluetooth-proxy.md
           - Addons:
             - Bottle Addon: products/pump1/addons/attaching-bottle-to-pump-1.md
             - Inlet and Outlet Tube Addons: products/pump1/addons/attaching-tubes-to-pump-1.md
@@ -507,6 +509,7 @@ nav:
           - Additional Info:
             - General Tips: products/btn1/setup/general-tips.md
             - Sensor Definitions: products/btn1/setup/sensor-definitions.md
+            - Bluetooth Proxy: products/btn1/additional-info/bluetooth-proxy.md
             - Prevent Sleep: products/btn1/additional-info/prevent-sleep.md
             - How To Wake Up Your Sensor: products/btn1/battery-sensors/wake-up-battery-sensor.md
           - Examples:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to Apollo Docs!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
  
  IMPORTANT: This PR must target the `dev` branch, not `main`.
  PRs against `main` will not be merged. Switch the base branch to `dev`
  using the dropdown above.
-->

## What does this implement/fix?

Follow-up to #939, reworking the Bluetooth Proxy guide layout based on review:

- General page: product tabs moved to the top of Method 1, and each tab now contains the complete walkthrough (steps 1-10 with that product's codeblock) instead of only the codeblock. Every product gets its own tab; PLT-1B and TEMP-1B are no longer combined with their siblings.
- Product pages: now use Method 1 / Method 2 content tabs at the top so readers pick one path.
- All products are now covered: R-PRO-1, PUMP-1, and BTN-1 (which have no `_BLE.yaml` in their repos) get a tab with an admonition pointing to Method 2, plus their own Additional Info page with only the manual method. The BTN-1 admonition notes sleep must be disabled and links the Prevent Sleep guide. BTN-1 sits last in the tab order.
- New nested `method1-<product>.md` snippets bundle the shared steps with each product's codeblock, so every page is a few include lines and the general tab and product page render from the same source.
- Wording fix: the `_BLE.yaml` files are referred to as firmware instead of fork.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Typo / wording fix
- [ ] Content update (correcting outdated info, adding missing steps, clarifications)
- [x] New page or new product section
- [ ] Page move / rename (redirect added in `mkdocs.yml`)
- [ ] Image / screenshot update
- [ ] Nav / structure change
- [ ] Site config or theme change
- [ ] CI / workflows / dependencies - Does not publish

## Checklist:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

  - [x] This PR targets the `dev` branch (not `main`)
  - [x] Changes previewed locally with `mkdocs serve`
  - [ ] If pages were moved or renamed, redirects were added to `mkdocs.yml`
  - [x] If new pages were added, nav was updated in `mkdocs.yml`

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized Bluetooth Proxy setup guides with improved method selection interface.
  * Added Bluetooth Proxy documentation for BTN-1, R-PRO-1, and PUMP-1 products.
  * Updated documentation layout for existing products (AIR-1, MSR-1, MSR-2, MTR-1, PLT-1, PLT-1B, TEMP-1, TEMP-1B) to use consistent tabbed method presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->