### PR TITLE
Add ESPHome Starter Kit buy buttons

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,21 +42,24 @@ description: >-
   }
 </style>
 
-<a href="https://wiki.apolloautomation.com/products/ESPHome-Starter-Kit/start-here/" style="display: block; text-decoration: none; color: inherit; margin: 1.5em 0;">
-  <div class="apollo-esk-card" style="background: #4379AA; border-radius: 12px; padding: 24px 28px; position: relative; overflow: hidden; min-height: 260px;">
-    <div class="apollo-esk-text" style="max-width: calc(100% - 320px);">
-      <div style="color: #9ABD32; font-size: 13px; font-weight: 600; letter-spacing: 0.4px; text-transform: uppercase;">
-        Spotlight
-      </div>
-      <h2 style="color: white; font-size: 28px; font-weight: 600; margin: 8px 0 6px;">ESPHome Starter Kit</h2>
-      <p style="color: #D4E8F8; font-size: 15px; margin: 0 0 16px; line-height: 1.5;">Build your first smart sensor from scratch.</p>
-      <span style="display: inline-flex; align-items: center; gap: 8px; background: #9ABD32; color: #1F425F; padding: 11px 22px; border-radius: 8px; font-weight: 600; font-size: 15px;">
-        View the setup guide →
-      </span>
+<div class="apollo-esk-card" style="background: #4379AA; border-radius: 12px; padding: 24px 28px; position: relative; overflow: hidden; min-height: 260px; margin: 1.5em 0;">
+  <div class="apollo-esk-text" style="max-width: calc(100% - 320px);">
+    <div style="color: #9ABD32; font-size: 13px; font-weight: 600; letter-spacing: 0.4px; text-transform: uppercase;">
+      Spotlight
     </div>
-    <img class="apollo-esk-img" src="assets/esphome-starter-kit-at-sotoh-2026.jpg" alt="ESPHome Starter Kit" />
+    <h2 style="color: white; font-size: 28px; font-weight: 600; margin: 8px 0 6px;">ESPHome Starter Kit</h2>
+    <p style="color: #D4E8F8; font-size: 15px; margin: 0 0 16px; line-height: 1.5;">Build your first smart sensor from scratch.</p>
+    <div style="display: flex; flex-wrap: wrap; gap: 28px;">
+      <a href="https://wiki.apolloautomation.com/products/ESPHome-Starter-Kit/start-here/" style="display: inline-flex; align-items: center; gap: 8px; background: #9ABD32; color: #1F425F; padding: 11px 22px; border-radius: 8px; font-weight: 600; font-size: 15px; text-decoration: none;">
+        View the setup guide →
+      </a>
+      <a href="https://apolloautomation.com/products/esk-1-esphome-starter-kit" style="display: inline-flex; align-items: center; gap: 8px; background: white; color: #1F425F; padding: 11px 22px; border-radius: 8px; font-weight: 600; font-size: 15px; text-decoration: none;">
+        Buy now →
+      </a>
+    </div>
   </div>
-</a>
+  <img class="apollo-esk-img" src="assets/esphome-starter-kit-at-sotoh-2026.jpg" alt="ESPHome Starter Kit" />
+</div>
 
 &nbsp;
 

--- a/docs/products/ESPHome-Starter-Kit/setup/first-steps.md
+++ b/docs/products/ESPHome-Starter-Kit/setup/first-steps.md
@@ -8,6 +8,8 @@ This guide walks you through installing the ESPHome Device Builder app, and maki
 
 By the end you'll have your ESPHome Starter Kit flashed with a working configuration, showing up in Home Assistant, and reachable in a browser at its IP address or http://esphome-starter-kit.local via its built-in web server.
 
+[:material-cart: Buy the ESPHome Starter Kit](https://apolloautomation.com/products/esk-1-esphome-starter-kit){ .md-button .md-button--primary }
+
 !!! tip "Click the (+) for extra context"
 
     <div markdown class="annotate">

--- a/docs/products/ESPHome-Starter-Kit/start-here.md
+++ b/docs/products/ESPHome-Starter-Kit/start-here.md
@@ -6,6 +6,8 @@ description: Landing page of the ESPHome Starter Kit QR Code.
 
 Welcome to the start of your ESPHome journey with the all-new **ESPHome Starter Kit**!
 
+[:material-cart: Buy the ESPHome Starter Kit](https://apolloautomation.com/products/esk-1-esphome-starter-kit){ .md-button .md-button--primary }
+
 ![](../../assets/esphome-starter-kit-exploded-with-box-1.png)
 
 By the end of this wiki you'll know how to:


### PR DESCRIPTION
Adds a "Buy now" call to action for the ESPHome Starter Kit in three spots:

- **Home page spotlight** - new "Buy now" button next to "View the setup guide". Converted the card wrapper from a single full-card link to a div so both buttons are real links.
- **Start Here** - buy button under the intro.
- **First Steps** - buy button under the intro.

All link to https://apolloautomation.com/products/esk-1-esphome-starter-kit. The two content-page buttons use the standard `md-button--primary` style so they stay CloudCannon-editable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Redesigned homepage Spotlight card with new call-to-action buttons ("View the setup guide" and "Buy now") for improved navigation and user experience.
  * Added purchase links for the ESPHome Starter Kit to documentation pages, making it easier to access product information and shopping options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->