### PR TITLE
Fix broken Next link on Button Toggles a Room Light page

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/everyday-use/button-toggles-room-light.md
+++ b/docs/products/ESPHome-Starter-Kit/everyday-use/button-toggles-room-light.md
@@ -80,6 +80,6 @@ Press the button on the Button module. The light you targeted toggles. Press aga
 
     Any light in your home - a bedside lamp, a ceiling group, a smart bulb strip - is one button press away. Swap `light.toggle` for `light.turn_on` with a `brightness_pct` to land on a specific brightness, or target a light group to control a whole room at once.
 
-<a href="trash-night-reminder/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Next - Trash Night Reminder</a>
+<a href="../trash-night-reminder/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Next - Trash Night Reminder</a>
 
 --8<-- "_snippets/community-help.md"


### PR DESCRIPTION
The **Next - Trash Night Reminder** button on the Button Toggles a Room Light page used a relative href of `trash-night-reminder/`, which mkdocs resolved against the current page's directory URL, producing `.../everyday-use/button-toggles-room-light/trash-night-reminder/` (404).

Changed to `../trash-night-reminder/`, matching the convention used by every other Starter Kit Next button (e.g. `motion-activated-light.md` → `../temp-reactive-leds/`).

Fixes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a navigation link on the “Button Toggles a Room Light” page so it points to the correct related guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->