### PR TITLE
Add NowCast AQI section to AIR-1 general tips

### DIFF
--- a/docs/homey/products/air1/setup/general-tips.md
+++ b/docs/homey/products/air1/setup/general-tips.md
@@ -51,6 +51,18 @@ The **U.S. Environmental Protection Agency (EPA)**<a href="https://www.airnow.go
 
 ---
 
+###### NowCast AQI
+
+<a href="https://esphome.io/components/sensor/aqi/" target="_blank" rel="noreferrer nofollow noopener">NowCast AQI</a> takes your PM2.5 and PM10 readings and converts them into a single 0–500 number using the EPA's formula. That number maps directly to the AQI categories in the table above: bigger = worse.
+
+The AIR-1 calculates this automatically and exposes it as a sensor in Home Assistant.
+
+!!! tip "NowCast AQI is easier to automate and understand than raw PM"
+
+    Instead of comparing µg/m³ values across PM1, PM2.5, PM4, and PM10, you get one number. Set an automation to trigger at 100 (Moderate) or 150 (Unhealthy for Sensitive Groups) and anyone in your household can understand why it fired.
+
+---
+
 ###### Indoor Air Quality Notes
 
 * **PM1** and **PM2.5** are especially important for indoor air monitoring since these smaller particles are more likely to come from cooking, candles, smoking, or inadequate ventilation.

--- a/docs/products/air1/setup/general-tips.md
+++ b/docs/products/air1/setup/general-tips.md
@@ -56,6 +56,18 @@ The **U.S. Environmental Protection Agency (EPA)**<a href="https://www.airnow.go
 
 ---
 
+###### NowCast AQI
+
+<a href="https://esphome.io/components/sensor/aqi/" target="_blank" rel="noreferrer nofollow noopener">NowCast AQI</a> takes your PM2.5 and PM10 readings and converts them into a single 0–500 number using the EPA's formula. That number maps directly to the AQI categories in the table above: bigger = worse.
+
+The AIR-1 calculates this automatically and exposes it as a sensor in Home Assistant.
+
+!!! tip "NowCast AQI is easier to automate and understand than raw PM"
+
+    Instead of comparing µg/m³ values across PM1, PM2.5, PM4, and PM10, you get one number. Set an automation to trigger at 100 (Moderate) or 150 (Unhealthy for Sensitive Groups) and anyone in your household can understand why it fired.
+
+---
+
 ###### Indoor Air Quality Notes
 
 * **PM1** and **PM2.5** are especially important for indoor air monitoring since these smaller particles are more likely to come from cooking, candles, smoking, or inadequate ventilation.


### PR DESCRIPTION
## Summary
- Adds a NowCast AQI section to the AIR-1 general tips page (HA and Homey variants)
- Explains that NowCast AQI converts PM2.5/PM10 into a single 0-500 human-readable number using the EPA formula
- Links to the ESPHome AQI docs for more detail on how the calculation works
- Tip corrected: the real benefit is readability and ease of automation vs. raw ug/m3 values, not response speed

## Test plan
- [ ] Verify NowCast AQI section appears after the EPA AQI table
- [ ] Confirm ESPHome link opens correctly

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “NowCast AQI” section to AIR-1 setup guides.
  * Explained how the device combines PM2.5 and PM10 readings into a single AQI value from 0–500.
  * Clarified how the AQI value maps to standard air quality categories and that it appears as a sensor in Home Assistant.
  * Included suggested automation thresholds for common alert levels, such as Moderate and Unhealthy for Sensitive Groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->