### PR TITLE
Remove unreliable Test it section from Trash Night Reminder

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/everyday-use/trash-night-reminder.md
+++ b/docs/products/ESPHome-Starter-Kit/everyday-use/trash-night-reminder.md
@@ -197,14 +197,6 @@ Add four triggers, one at a time. Each one is a **Calendar** trigger, and each g
     mode: single
     ```
 
-## Test it
-
-Rather than waiting for your next pickup night, add a short test event to confirm everything fires.
-
-1. Open the **Calendar** view and add a new event on the **Trash** calendar starting one minute from now and ending two minutes from now.
-2. Watch the RGB LEDs. They should turn amber at the start time and go off at the end time.
-3. Delete the test event once you're done.
-
 !!! success "Your kit is now a physical reminder for Home Assistant events!"
 
     The same pattern works for any calendar-driven reminder - medication schedules, bin days for a second home, watering days for the garden. Swap the colors, the calendar name, or the action and you have a new reminder with no extra hardware.


### PR DESCRIPTION
The **Test it** step had users add a calendar event starting a minute out, but Home Assistant only refreshes calendar triggers about every 15 minutes, so it wouldn't fire for most people (reported in #969).

Dropping the section rather than documenting the re-save workaround. The other Everyday Use pages (Motion-Activated Room Lights, Temperature on Your Dashboard) don't carry a test step; those automations self-verify, and this keeps the section consistent.

Fixes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)