### PR TITLE
Update AIR-1 LED Indicator page (source/brightness)

### DIFF
--- a/docs/products/air1/additional-info/led-indicator.md
+++ b/docs/products/air1/additional-info/led-indicator.md
@@ -8,18 +8,24 @@ The AIR-1's three onboard RGB LEDs can double as an air quality gauge. Pick what
 
 !!! note "Requires firmware 26.6.25.1 or newer"
 
-    The **LED Indicator Source** control ships in AIR-1 firmware 26.6.25.1 and later. If you don't see it, [update your firmware](../../general/calibrating-and-updating/updating-firmware.md) first.
+    The **Air Quality LED Source** control ships in AIR-1 firmware 26.6.25.1 and later. If you don't see it, [update your firmware](../../general/calibrating-and-updating/updating-firmware.md) first.
 
-## Pick what the LEDs track
+## Turn it on
 
-Open the AIR-1 device in Home Assistant and find the **LED Indicator Source** dropdown.
+The indicator is off by default. Open the AIR-1 device in Home Assistant, find the **Air Quality LED Source** dropdown, and pick what you want the LEDs to track.
 
 | Option | LEDs show |
 | --- | --- |
-| **[NowCast AQI](../setup/general-tips.md#nowcast-aqi)** | US EPA Air Quality Index (default) |
+| **Off** | LEDs stay dark (default) |
+| **[NowCast AQI](../setup/general-tips.md#nowcast-aqi)** | US EPA Air Quality Index |
 | **[CO2](../setup/general-tips.md#scd40-co2-sensor)** | Carbon dioxide, in ppm |
 | **[VOC Index](../setup/general-tips.md#voc-index)** | Sensirion VOC Index |
-| **Off** | LEDs stay dark |
+
+Switch back to **Off** any time to turn the indicator off and leave the LEDs free for your own automations.
+
+## Set the brightness
+
+Drag the **Air Quality LED Brightness** slider to dim the LEDs, handy if the AIR-1 sits in a bedroom. It runs from 5% to 100% (default 100%) and applies the moment you change it.
 
 ## Color scale
 
@@ -38,8 +44,8 @@ The VOC bands line up with the **VOC Quality** sensor (Improved, Normal, Abnorma
 
 ## Tips and quirks
 
-- The color refreshes about every 10 seconds. Change the dropdown and it catches up on the next reading.
-- Choose **CO2** and the first color can take up to a minute on a cold start, because the CO₂ sensor reports once a minute. The firmware gives it a nudge at boot, so it's usually quicker than that.
-- A sensor that's still warming up reads as *unknown*. The LEDs wait for a real value rather than flashing a false hazardous color.
+- The color updates whenever the selected sensor reports a fresh reading, so NowCast AQI and VOC refresh every few seconds while CO₂ updates about once a minute.
+- With **CO2** selected, the first color appears once the SCD40 has a reading, up to a minute after boot. That wait is deliberate: the sensor needs a moment to settle, and an early reading would not be trustworthy.
+- A sensor that's still warming up reads as *unknown*. The LEDs stay off until there's a real value rather than flashing a false color.
 
 [Join our Discord if you need more help! :simple-discord:](https://link.apolloautomation.com/discord){ .md-button }


### PR DESCRIPTION
Updates the AIR-1 LED Indicator page to match firmware changes in ApolloAutomation/AIR-1 #101:

- Control renamed to **Air Quality LED Source**
- Now defaults to **Off** (opt-in); page reframed around turning it on
- Documents the new **Air Quality LED Brightness** slider (5-100%)
- Corrected timing notes: event-driven updates, and CO2 first color waits for a settled reading (the boot nudge was removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the AIR-1 LED Indicator guide to use the new **Air Quality LED Source** name.
  * Reorganized the instructions into clearer sections for turning the LEDs on and adjusting brightness.
  * Clarified brightness settings, including the **5%–100%** range and **100%** default.
  * Refined behavior notes for update timing, CO₂ startup delay, and sensor warm-up/unknown states so the LED behavior is easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->