### PR TITLE
Add TEMP-1 hot water recirculation use-case page and fix broken doc links

### DIFF
--- a/docs/assets/temp1-hot-water-recirculation.svg
+++ b/docs/assets/temp1-hot-water-recirculation.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 600" width="960" height="600" font-family="'Segoe UI', system-ui, -apple-system, sans-serif" role="img" aria-label="Diagram of the hot water recirculation plumbing under the sink: house water heater feeds wall hot and cold lines, a circulator pump recirculates the wall loop, a TEMP-1 probe reads the wall hot line, a Bosch mini tank provides instant hot water, and a 3-way motorized valve selects which source feeds the sinks.">
+  <defs>
+    <marker id="ahHot" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto"><path d="M0,0 L9,4.5 L0,9 Z" fill="#d64545"/></marker>
+    <marker id="ahCold" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto"><path d="M0,0 L9,4.5 L0,9 Z" fill="#3f7fd0"/></marker>
+    <marker id="ahRecirc" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto"><path d="M0,0 L9,4.5 L0,9 Z" fill="#d98324"/></marker>
+    <g id="bolt"><circle r="11" fill="#f4b400" stroke="#7a5c00" stroke-width="1.5"/><path d="M2,-6 L-4,1 L-0.5,1 L-2,6 L4,-1 L0.5,-1 Z" fill="#5a4400"/></g>
+  </defs>
+
+  <rect x="0" y="0" width="960" height="600" rx="16" fill="#f6f8fa"/>
+  <text x="480" y="34" text-anchor="middle" font-size="19" font-weight="700" fill="#1b2530">Hot Water Recirculation with TEMP-1</text>
+
+  <!-- WALL divider -->
+  <line x1="235" y1="64" x2="235" y2="548" stroke="#c2cad3" stroke-width="2" stroke-dasharray="7 6"/>
+  <text x="235" y="566" text-anchor="middle" font-size="12" fill="#7a8694">WALL  (house side ◀ | ▶ under-sink)</text>
+
+  <!-- ===== PIPES (drawn first, under boxes) ===== -->
+  <!-- wall hot lane -->
+  <path d="M180,330 V160 H650 V250" fill="none" stroke="#d64545" stroke-width="6" marker-end="url(#ahHot)"/>
+  <!-- wall cold lane -->
+  <path d="M180,420 V456 H880" fill="none" stroke="#3f7fd0" stroke-width="6"/>
+  <!-- cold up into Bosch -->
+  <path d="M480,456 V480" fill="none" stroke="#3f7fd0" stroke-width="6"/>
+  <!-- cold up to sinks -->
+  <path d="M860,456 V172" fill="none" stroke="#3f7fd0" stroke-width="6" marker-end="url(#ahCold)"/>
+  <!-- Bosch hot out to valve left input -->
+  <path d="M480,350 V300 H590" fill="none" stroke="#d64545" stroke-width="6" marker-end="url(#ahHot)"/>
+  <!-- valve output hot to sinks -->
+  <path d="M710,300 H820 V172" fill="none" stroke="#d64545" stroke-width="6" marker-end="url(#ahHot)"/>
+  <!-- recirculation loop through pump (hot lane -> pump -> cold lane, back to heater) -->
+  <path d="M285,160 V300" fill="none" stroke="#d98324" stroke-width="4" stroke-dasharray="6 5"/>
+  <path d="M285,330 V456" fill="none" stroke="#d98324" stroke-width="4" stroke-dasharray="6 5" marker-end="url(#ahRecirc)"/>
+
+  <!-- ===== COMPONENTS ===== -->
+  <!-- House water heater -->
+  <rect x="30" y="300" width="150" height="160" rx="10" fill="#ffffff" stroke="#2b3a4a" stroke-width="2"/>
+  <text x="105" y="372" text-anchor="middle" font-size="13" font-weight="600" fill="#1b2530">House</text>
+  <text x="105" y="390" text-anchor="middle" font-size="13" font-weight="600" fill="#1b2530">Water Heater</text>
+  <text x="105" y="410" text-anchor="middle" font-size="11" fill="#7a8694">(main, unlimited)</text>
+
+  <!-- Circulator pump -->
+  <rect x="232" y="284" width="106" height="62" rx="9" fill="#ffffff" stroke="#2b3a4a" stroke-width="2"/>
+  <text x="285" y="309" text-anchor="middle" font-size="12" font-weight="600" fill="#1b2530">Circulator</text>
+  <text x="285" y="325" text-anchor="middle" font-size="12" font-weight="600" fill="#1b2530">Pump</text>
+  <use href="#bolt" x="330" y="290"/>
+
+  <!-- TEMP-1 probe -->
+  <line x1="360" y1="160" x2="360" y2="196" stroke="#2e7d46" stroke-width="3"/>
+  <circle cx="360" cy="160" r="5" fill="#2e7d46"/>
+  <rect x="300" y="196" width="128" height="52" rx="9" fill="#eaf5ee" stroke="#2e7d46" stroke-width="2"/>
+  <text x="364" y="217" text-anchor="middle" font-size="12" font-weight="700" fill="#1f5630">Apollo TEMP-1</text>
+  <text x="364" y="234" text-anchor="middle" font-size="10.5" fill="#1f5630">reads wall-hot temp</text>
+  <use href="#bolt" x="420" y="202"/>
+
+  <!-- Bosch mini tank -->
+  <rect x="410" y="350" width="140" height="130" rx="10" fill="#ffffff" stroke="#2b3a4a" stroke-width="2"/>
+  <text x="480" y="408" text-anchor="middle" font-size="13" font-weight="600" fill="#1b2530">Bosch</text>
+  <text x="480" y="426" text-anchor="middle" font-size="12" fill="#1b2530">Mini Tank</text>
+  <text x="480" y="444" text-anchor="middle" font-size="11" fill="#7a8694">2.5 gal, instant</text>
+  <use href="#bolt" x="535" y="360"/>
+
+  <!-- 3-way motorized valve -->
+  <rect x="610" y="260" width="100" height="80" rx="10" fill="#fff4e6" stroke="#d98324" stroke-width="2.5"/>
+  <text x="660" y="294" text-anchor="middle" font-size="12" font-weight="700" fill="#8a5310">3-way</text>
+  <text x="660" y="311" text-anchor="middle" font-size="11" fill="#8a5310">motorized</text>
+  <text x="660" y="327" text-anchor="middle" font-size="11" fill="#8a5310">valve</text>
+  <use href="#bolt" x="700" y="266"/>
+
+  <!-- Sinks -->
+  <rect x="800" y="120" width="120" height="50" rx="8" fill="#ffffff" stroke="#2b3a4a" stroke-width="2"/>
+  <text x="860" y="150" text-anchor="middle" font-size="12.5" font-weight="600" fill="#1b2530">Bathroom Sinks</text>
+  <text x="860" y="110" text-anchor="middle" font-size="10.5" fill="#7a8694">hot + cold to taps</text>
+
+  <!-- valve source labels -->
+  <text x="660" y="250" text-anchor="middle" font-size="10" fill="#8a5310">powered → wall · off → Bosch</text>
+
+  <!-- ===== LEGEND ===== -->
+  <g font-size="12" fill="#1b2530">
+    <line x1="40" y1="520" x2="78" y2="520" stroke="#d64545" stroke-width="6"/><text x="84" y="524">Hot</text>
+    <line x1="140" y1="520" x2="178" y2="520" stroke="#3f7fd0" stroke-width="6"/><text x="184" y="524">Cold</text>
+    <line x1="244" y1="520" x2="282" y2="520" stroke="#d98324" stroke-width="4" stroke-dasharray="6 5"/><text x="288" y="524">Recirculation flow</text>
+    <use href="#bolt" x="448" y="520"/><text x="464" y="524">Switched smart-strip outlet</text>
+  </g>
+</svg>

--- a/docs/homey/products/air1/setup/general-tips.md
+++ b/docs/homey/products/air1/setup/general-tips.md
@@ -145,7 +145,7 @@ The latest AIR-1 firmware keeps the SCD40 calibrated automatically. The sensor a
 
 !!! warning "Auto calibration needs regular fresh air"
 
-    If your AIR-1 sits in a space that rarely gets fresh air (a sealed office, a basement, a grow room), automatic self-calibration will slowly drag the CO<sub>2</sub> readings down. Turn off the **CO2 Auto Calibration** switch in your device's settings and follow the [manual calibration guide](../../../general/calibrating-and-updating/co2-calibration/) every 1 to 2 years instead.
+    If your AIR-1 sits in a space that rarely gets fresh air (a sealed office, a basement, a grow room), automatic self-calibration will slowly drag the CO<sub>2</sub> readings down. Turn off the **CO2 Auto Calibration** switch in your device's settings and follow the [manual calibration guide](../../general/calibrating-and-updating/co2-calibration.md) every 1 to 2 years instead.
 
 ![](/assets/co2-levels-drop-after-hvac-on.png)
 

--- a/docs/products/ESPHome-Starter-Kit/automations/button-controlled-leds.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/button-controlled-leds.md
@@ -14,15 +14,15 @@ This tutorial uses the Button module and the RGB & Buzzer module connected to th
 
     Work through these pages first. This tutorial assumes your device is flashed and both modules are connected:
 
-    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps/) to create your starter kit device in ESPHome Device Builder.
-    * [Adding the Button Module](/products/ESPHome-Starter-Kit/modules/button-module/) to wire up the input.
-    * [Adding the LED & Buzzer Module](/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module/) to wire up the RGB output.
+    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps.md) to create your starter kit device in ESPHome Device Builder.
+    * [Adding the Button Module](/products/ESPHome-Starter-Kit/modules/button-module.md) to wire up the input.
+    * [Adding the LED & Buzzer Module](/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module.md) to wire up the RGB output.
 
 ## Build the automation
 
 ESPHome Device Builder has a new GUI for building <a href="https://esphome.io/automations/" target="_blank" rel="noreferrer nofollow noopener">automations</a>, so you can wire a trigger to an action without hand-writing YAML. The trigger is the *when* of the automation, the thing that makes it fire. The action is the *then do*, what happens when it fires. If you've built automations in Home Assistant, this is the same mental model.
 
-1.  Open your starter kit device in ESPHome Device Builder and click **Edit**. If you need a refresher on the editor, see the [Device Builder Tour](/products/ESPHome-Starter-Kit/learning-the-basics/device-builder-tour/#editor).
+1.  Open your starter kit device in ESPHome Device Builder and click **Edit**. If you need a refresher on the editor, see the [Device Builder Tour](/products/ESPHome-Starter-Kit/learning-the-basics/device-builder-tour.md#editor).
 2.  In the editor's left pane, expand the **Automations** dropdown and click **Add Automation**.
 
     ![](../../../assets/esphome-device-builder-add-automation.gif)
@@ -72,7 +72,7 @@ ESPHome Device Builder has a new GUI for building <a href="https://esphome.io/au
             - light.toggle: rgb_leds
     ```
 
-    See [Device Builder Tour → YAML editor (right)](/products/ESPHome-Starter-Kit/learning-the-basics/device-builder-tour/#yaml-editor-right) for the full breakdown of the YAML pane.
+    See [Device Builder Tour → YAML editor (right)](/products/ESPHome-Starter-Kit/learning-the-basics/device-builder-tour.md#yaml-editor-right) for the full breakdown of the YAML pane.
 
 ## Install the firmware
 

--- a/docs/products/ESPHome-Starter-Kit/learning-the-basics/how-esphome-talks-to-home-assistant.md
+++ b/docs/products/ESPHome-Starter-Kit/learning-the-basics/how-esphome-talks-to-home-assistant.md
@@ -52,7 +52,7 @@ For a single device, the on-device web page is often enough. For anything that t
 
     Some router setups (notably VLANs and segmented networks) block mDNS broadcasts. If your device never shows up under **Discovered**, add the integration manually using the device's IP address.
 
-    For UniFi networks specifically, see our [UniFi mDNS troubleshooting guide](../../../general/troubleshooting/ubiquiti-unifi-mdns-auto-discover-issue/).
+    For UniFi networks specifically, see our [UniFi mDNS troubleshooting guide](../../general/troubleshooting/ubiquiti-unifi-mdns-auto-discover-issue.md).
 
 <a href="../what-is-secrets-yaml/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Back - What is secrets.yaml?</a> <a href="../../tutorials/connect-to-home-assistant/" class="md-button md-button--primary"><img src="/assets/esphome-logo.svg" /> Tutorial - Connect to Home Assistant</a>
 

--- a/docs/products/ESPHome-Starter-Kit/modules/apollo-breakout-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/apollo-breakout-module.md
@@ -16,8 +16,8 @@ The Breakout Module gives your starter kit room to grow. It breaks the ESP32-C6'
 
     Work through the two prerequisites first:
 
-    * [Start Here](/products/ESPHome-Starter-Kit/start-here/) to snap the module off the panel.
-    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps/) to install ESPHome Device Builder and create your starter kit device.
+    * [Start Here](/products/ESPHome-Starter-Kit/start-here.md) to snap the module off the panel.
+    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps.md) to install ESPHome Device Builder and create your starter kit device.
 
 #### Prerequisite
 

--- a/docs/products/ESPHome-Starter-Kit/modules/button-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/button-module.md
@@ -12,8 +12,8 @@ The button module is the first input your starter kit gets, and the fastest way 
 
     Work through the two prerequisites first:
 
-    * [Start Here](/products/ESPHome-Starter-Kit/start-here/) to snap the button module off the panel.
-    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps/) to install ESPHome Device Builder and create your starter kit device.
+    * [Start Here](/products/ESPHome-Starter-Kit/start-here.md) to snap the button module off the panel.
+    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps.md) to install ESPHome Device Builder and create your starter kit device.
 
 #### Prerequisite
 

--- a/docs/products/ESPHome-Starter-Kit/modules/motion-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/motion-module.md
@@ -12,8 +12,8 @@ The Motion Module turns your starter kit into a motion sensor. By the end of thi
 
     Work through the two prerequisites first:
 
-    * [Start Here](/products/ESPHome-Starter-Kit/start-here/) to snap the motion module off the panel.
-    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps/) to install ESPHome Device Builder and create your starter kit device.
+    * [Start Here](/products/ESPHome-Starter-Kit/start-here.md) to snap the motion module off the panel.
+    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps.md) to install ESPHome Device Builder and create your starter kit device.
 
 #### Prerequisite
 

--- a/docs/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module.md
@@ -12,8 +12,8 @@ The LED & Buzzer is the starter kit's notification module, a strip of ten addres
 
     Work through the two prerequisites first:
 
-    * [Start Here](/products/ESPHome-Starter-Kit/start-here/) to snap the RGB & Buzzer module off the panel.
-    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps/) to install ESPHome Device Builder and create your starter kit device.
+    * [Start Here](/products/ESPHome-Starter-Kit/start-here.md) to snap the RGB & Buzzer module off the panel.
+    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps.md) to install ESPHome Device Builder and create your starter kit device.
 
 #### Prerequisite
 

--- a/docs/products/ESPHome-Starter-Kit/modules/temperature-humidity-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/temperature-humidity-module.md
@@ -13,8 +13,8 @@ The temperature and humidity module is your starter kit's first environmental se
 
     Work through the two prerequisites first:
 
-    * [Start Here](/products/ESPHome-Starter-Kit/start-here/) to snap the temperature and humidity module off the panel.
-    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps/) to install ESPHome Device Builder and create your starter kit device.
+    * [Start Here](/products/ESPHome-Starter-Kit/start-here.md) to snap the temperature and humidity module off the panel.
+    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps.md) to install ESPHome Device Builder and create your starter kit device.
 
 #### Prerequisite
 

--- a/docs/products/ESPHome-Starter-Kit/setup/first-steps.md
+++ b/docs/products/ESPHome-Starter-Kit/setup/first-steps.md
@@ -222,7 +222,7 @@ Before we continue, confirm that you installed the ESPHome Device Builder, confi
 
 ### Test your LED
 
-Your kit's default project includes the [**Web Server**](../../learning-the-basics/core-components/#web-server) component, which lets you navigate to the IP address of your device or the hostname.local such as <a href="http://esphome-starter-kit.local/" target="_blank" rel="noreferrer nofollow noopener">http://esphome-starter-kit.local/</a>
+Your kit's default project includes the [**Web Server**](../learning-the-basics/core-components.md#web-server) component, which lets you navigate to the IP address of your device or the hostname.local such as <a href="http://esphome-starter-kit.local/" target="_blank" rel="noreferrer nofollow noopener">http://esphome-starter-kit.local/</a>
 
 !!! warning "Use http:// not https://"
 

--- a/docs/products/ESPHome-Starter-Kit/tutorials/light-effects.md
+++ b/docs/products/ESPHome-Starter-Kit/tutorials/light-effects.md
@@ -12,8 +12,8 @@ Out of the box, your RGB module turns on, turns off, and changes color. ESPHome 
 
     Work through these pages first. This tutorial assumes your device is flashed and has an addressable RGB light component already configured (either the **Onboard RGB LED** or the **RGB LEDs** from the LED & Buzzer module):
 
-    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps/) to create your starter kit device in ESPHome Device Builder.
-    * [Adding the LED & Buzzer Module](/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module/) if you're using the LED & Buzzer module.
+    * [First Steps](/products/ESPHome-Starter-Kit/setup/first-steps.md) to create your starter kit device in ESPHome Device Builder.
+    * [Adding the LED & Buzzer Module](/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module.md) if you're using the LED & Buzzer module.
 
 ## Add the effects
 
@@ -57,7 +57,7 @@ With the device back online, open the local web page at `http://esphome-starter-
 
 ![](../../../assets/esphome-device-builder-test-effects-web-server.gif)
 
-If you've already followed [Connect to Home Assistant](/products/ESPHome-Starter-Kit/tutorials/connect-to-home-assistant/), the same **Effect** dropdown shows up on the light entity card in Home Assistant.
+If you've already followed [Connect to Home Assistant](/products/ESPHome-Starter-Kit/tutorials/connect-to-home-assistant.md), the same **Effect** dropdown shows up on the light entity card in Home Assistant.
 
 !!! success "You just edited YAML!"
 

--- a/docs/products/air1/faq.md
+++ b/docs/products/air1/faq.md
@@ -61,7 +61,7 @@ description: Frequently asked questions about the AIR-1 environmental sensor, in
 
 15\. **How do I calibrate the CO2 sensor?**
 
-* You usually don't need to. The latest AIR-1 firmware enables automatic self-calibration, which keeps the SCD40 accurate as long as the sensor sees fresh air (about 420 ppm) at least once a week. If your AIR-1 sits in a space that rarely gets fresh air (a sealed office, a basement, a grow room), turn off the **CO2 Auto Calibration** switch on the device page and follow the [manual calibration guide](../../general/calibrating-and-updating/co2-calibration/) every 1 to 2 years instead.
+* You usually don't need to. The latest AIR-1 firmware enables automatic self-calibration, which keeps the SCD40 accurate as long as the sensor sees fresh air (about 420 ppm) at least once a week. If your AIR-1 sits in a space that rarely gets fresh air (a sealed office, a basement, a grow room), turn off the **CO2 Auto Calibration** switch on the device page and follow the [manual calibration guide](../general/calibrating-and-updating/co2-calibration.md) every 1 to 2 years instead.
 
 16\. **Does the AIR-1 work outdoors?**
 

--- a/docs/products/air1/setup/general-tips.md
+++ b/docs/products/air1/setup/general-tips.md
@@ -150,7 +150,7 @@ The latest AIR-1 firmware keeps the SCD40 calibrated automatically. The sensor a
 
 !!! warning "Auto calibration needs regular fresh air"
 
-    If your AIR-1 sits in a space that rarely gets fresh air (a sealed office, a basement, a grow room), automatic self-calibration will slowly drag the CO<sub>2</sub> readings down. Turn off the **CO2 Auto Calibration** switch on the device page and follow the [manual calibration guide](../../../general/calibrating-and-updating/co2-calibration/) every 1 to 2 years instead.
+    If your AIR-1 sits in a space that rarely gets fresh air (a sealed office, a basement, a grow room), automatic self-calibration will slowly drag the CO<sub>2</sub> readings down. Turn off the **CO2 Auto Calibration** switch on the device page and follow the [manual calibration guide](../../general/calibrating-and-updating/co2-calibration.md) every 1 to 2 years instead.
 
 ![](/assets/co2-levels-drop-after-hvac-on.png)
 

--- a/docs/products/general/calibrating-and-updating/co2-calibration-quick.md
+++ b/docs/products/general/calibrating-and-updating/co2-calibration-quick.md
@@ -6,7 +6,7 @@ description: Step by step guide for re-calibrating your SCD40 CO2 sensor
 
 !!! info "Your sensor calibrates itself"
 
-    The latest Apollo firmware enables the SCD40's automatic self-calibration by default on every device with the CO<sub>2</sub> sensor (AIR-1, R-PRO-1, MSR-2, and MTR-1), so you only need this guide if you turned the **CO2 Auto Calibration** switch off. See the [full calibration guide](../co2-calibration/) for how auto calibration works and when to turn it off.
+    The latest Apollo firmware enables the SCD40's automatic self-calibration by default on every device with the CO<sub>2</sub> sensor (AIR-1, R-PRO-1, MSR-2, and MTR-1), so you only need this guide if you turned the **CO2 Auto Calibration** switch off. See the [full calibration guide](co2-calibration.md) for how auto calibration works and when to turn it off.
 
 !!! tip "Calibrate manually every 1 to 2 years when auto calibration is off"
 

--- a/docs/products/plt1b/additional-info/insert-battery.md
+++ b/docs/products/plt1b/additional-info/insert-battery.md
@@ -10,28 +10,28 @@ description: How to Insert Battery on PLT-1B.
 
 1\. Gently press your thumb on the case above the stake and the lid should pop off.
 
-![](../../../assets/plt-1b-remove-case-lid.webp)
+![](/assets/plt-1b-remove-case-lid.webp)
 
 2\. Hold the case and push the stake down a bit, then gently lift it out of the bottom case section.
 
-![](../../../assets/plt-1b-lift-pcb-out-of-case.webp)
+![](/assets/plt-1b-lift-pcb-out-of-case.webp)
 
 3\. Flip the PLT-1B over and identify the `+` and `-` markings. The `+` is on the left side and the `-` is on the right side. Double check before going any further.
 
 4\. The top of the battery (the positive end, marked with a `+` and a small ring around the terminal) goes on the left side, matching the `+` on the PLT-1B.
 
-![](../../../assets/plt-1b-identify-top-of-18650-battery.webp)
+![](/assets/plt-1b-identify-top-of-18650-battery.webp)
 
 5\. Hold the PCB. You'll need to use a bit of force to push in the battery. Start with the right `-` side, then push in the left `+` side.
 
-![](../../../assets/plt-1b-insert-battery.webp)
+![](/assets/plt-1b-insert-battery.webp)
 
 6\. Flip the sensor back over and lay the PCB inside the case so it sits flat.
 
-![](../../../assets/plt-1b-place-pcb-in-case.webp)
+![](/assets/plt-1b-place-pcb-in-case.webp)
 
 7\. Line up the notch in the top left of the lid, then gently press down until the lid snaps into place.
 
-![](../../../assets/plt-1b-replace-case-lid.webp)
+![](/assets/plt-1b-replace-case-lid.webp)
 
 You have now installed or reinstalled the battery!

--- a/docs/products/temp1/examples/hot-water-recirculation.md
+++ b/docs/products/temp1/examples/hot-water-recirculation.md
@@ -1,0 +1,99 @@
+---
+title: Hot Water Recirculation with TEMP-1
+description: How a community member uses an Apollo TEMP-1 to drive a hot water recirculation loop, blending an instant mini tank with the main house heater and wasting no water down the drain.
+---
+# Hot Water Recirculation with TEMP-1
+
+!!! info "Contributed by Donovan"
+
+    This is a real setup shared by Donovan, an Apollo community member. We will flesh out the Home Assistant side once he shares his automations.
+
+There are two normal ways to get hot water at a sink, and each has a catch. A small under-sink tank gives you instant hot water with very little energy, but it runs out after a gallon or two. The main house water heater never runs out, but you either wait while cold water runs down the drain, or you get a cold-water sandwich when the tank water hands off to the line water.
+
+Donovan's setup uses an Apollo TEMP-1 to get both. Small draws come from a 2.5 gallon Bosch mini tank. When he knows he needs more, a button starts a recirculation loop that pulls hot water up from the house heater without running the tap, and the TEMP-1 tells Home Assistant the moment that line is hot enough to switch over. No water goes down the drain, and there is no cold-water sandwich.
+
+## How it works
+
+The TEMP-1 probe is zip-tied to the hot-water angle stop, so it reads the temperature of the hot line coming from the house heater. Everything else, the Bosch tank, the circulator pump, the motorized valve, and the TEMP-1 itself, plugs into a Kasa smart power strip that Home Assistant controls.
+
+1. **Idle.** The 3-way valve is unpowered, so the sinks are fed by the Bosch mini tank. Instant hot water, low energy.
+2. **Request hot water.** Donovan presses an Aqara Zigbee button when he knows he'll use more than a gallon or two.
+3. **Recirculate.** Home Assistant switches the circulator pump on. It pumps the cooled water from the hot line back into the cold line, pulling fresh hot water up from the house heater. Nothing runs down the drain.
+4. **Watch the line.** The TEMP-1 reports the angle-stop temperature every few seconds. The pump also has its own temperature sensor, and the smart strip watches its energy use, so the system knows when the pump finishes.
+5. **Switch over.** Once the line is hot, Home Assistant powers the valve so the sinks draw from the house heater, and shuts the pump outlet off so it won't run again when the water cools. Alexa announces "The hot water is ready."
+6. **Revert.** When the TEMP-1 sees the line drop below a set temperature, Home Assistant cuts power to the valve. A capacitor inside the valve stores just enough energy to rotate it back, so the sinks return to the Bosch tank.
+
+### Physical layout
+
+![Hot water recirculation plumbing: the house heater feeds wall hot and cold lines, a circulator pump recirculates the loop, the TEMP-1 reads the wall hot line, a Bosch mini tank supplies instant hot water, and a 3-way valve selects which source feeds the sinks.](/assets/temp1-hot-water-recirculation.svg)
+
+### Control logic
+
+```mermaid
+flowchart LR
+    IDLE["Idle:<br/>Bosch feeds the sinks<br/>(valve off)"]
+    PUMP["Pump ON:<br/>recirculate the wall loop,<br/>no water wasted"]
+    Q1{"Wall line<br/>up to temp?"}
+    WALL["Valve powered:<br/>house heater feeds the sinks<br/>(Alexa: hot water ready)"]
+    Q2{"Wall line<br/>cooled off?"}
+
+    IDLE -->|press Aqara button| PUMP --> Q1
+    Q1 -->|no| PUMP
+    Q1 -->|yes| WALL --> Q2
+    Q2 -->|no| WALL
+    Q2 -->|"yes: valve off, back to Bosch"| IDLE
+
+    classDef bosch fill:#4379AA,stroke:#2d5a8a,color:#fff;
+    classDef wall fill:#d64545,stroke:#a83232,color:#fff;
+    classDef temp fill:#2e7d46,stroke:#1f5630,color:#fff;
+    class IDLE bosch;
+    class WALL wall;
+    class Q1,Q2 temp;
+```
+
+## Parts
+
+| Part | Role in the loop |
+| --- | --- |
+| Apollo TEMP-1 + short temperature probe | Reads the hot line at the angle stop and reports it to Home Assistant |
+| Bosch ES2.5 mini tank (2.5 gal, 120 V) | Instant hot water for small draws |
+| AquaMotion AMH3K-7N circulator pump | Recirculates the loop to pull hot water up from the house heater |
+| US Solid 1/2" 3-way L-type motorized ball valve | Selects the hot source: unpowered feeds the Bosch, powered feeds the house heater |
+| TP-Link Kasa smart power strip | Switches the pump, valve, Bosch, and TEMP-1 outlets, and monitors energy use |
+| Aqara wireless mini switch (Zigbee) | The "I want hot water" button |
+| Alexa speaker | Announces when the line is ready |
+
+## TEMP-1 configuration
+
+For this to react quickly, the probe needs to report faster than its 60 second default. Donovan reports it every 3 seconds and keeps a 60 second heartbeat, so Home Assistant reacts fast while you can still tell at a glance that the probe is alive. Two guards keep the data clean: the `85.0` reading a DS18B20 sends at power-on is dropped, and readings are ignored when the **Select Probe** option is set to `Food`.
+
+For the full walkthrough of overriding probe YAML in the ESPHome Builder, including the simpler delta-plus-heartbeat pattern, see [How To Change The Temperature Probe Update Interval](../setup/temp1-change-temp-probe-update-interval.md).
+
+```yaml
+sensor:
+  - platform: dallas_temp
+    id: !extend temp_probe
+    update_interval: 3s
+    filters:
+      - lambda: |-
+          if (isnan(x)) {
+            return NAN;
+          }
+          if (x == 85.0) {
+              return NAN;
+          }
+          auto selected_probe = id(temp_probe_select).current_option();
+          if (selected_probe == "Food") {
+            return NAN;
+          }
+          return x - id(dallas_temperature_offset).state;
+      - or:
+          - delta: 1.1    # ~2°F; change to 2.0 for 2°C (~3.6°F) instead
+          - heartbeat: 60s
+```
+
+## Home Assistant automations
+
+!!! note "Work in progress"
+
+    The whole cycle is driven by Home Assistant automations. The button press starts the pump, a TEMP-1 threshold flips the valve and triggers the Alexa announcement, and a lower threshold reverts the valve. We'll add Donovan's actual automation YAML here once he shares it.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -369,6 +369,7 @@ nav:
                 - Alert Outside Range: products/temp1/examples/temp1-alert-example.md
                 - Use Cases: products/temp1/examples/use-cases.md
                 - Automations: products/temp1/examples/temp1-automation-examples.md
+                - Hot Water Recirculation: products/temp1/examples/hot-water-recirculation.md
               - Troubleshooting:
                 - TEMP-1 Boot Mode: products/temp1/troubleshooting/temp1-boot-mode.md
                 - Factory Re-Flash TEMP-1: products/temp1/troubleshooting/temp1-code.md


### PR DESCRIPTION
## New page: Hot Water Recirculation with TEMP-1

Adds a TEMP-1 > Examples page documenting a community setup (contributed by Donovan) that uses a TEMP-1 probe to run a hot water recirculation loop, blending an instant Bosch mini tank with the main house heater so there's no wasted water and no cold-water sandwich.

- Hand-built **SVG plumbing schematic** (`docs/assets/temp1-hot-water-recirculation.svg`)
- **Mermaid control-logic** diagram of the operating cycle (Apollo color classes)
- Parts list + the ESPHome probe config (3s update + 60s heartbeat), linking to the existing update-interval page
- HA automations left as a "work in progress" note until Donovan shares his YAML

## Drive-by: fix broken doc links flagged by `mkdocs build`

- **ESPHome Starter Kit** (7 pages): URL-style links now point at the `.md` source, anchors preserved
- **PLT-1B battery page**: images switched to root-absolute `/assets/...` so they resolve when the Homey page pulls them in via snippet
- **AIR-1 / general**: corrected `co2-calibration` relative-link depth (incl. the Homey duplicate)

Result: `INFO unrecognized links 7 -> 0`, all targeted "not found" warnings cleared. Remaining build warnings (cairo/social-card local env + other pre-existing links) left for a future pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)