### PR TITLE
Mirror hot water recirculation example onto TEMP-1B

### DIFF
--- a/docs/products/temp1/examples/hot-water-recirculation.md
+++ b/docs/products/temp1/examples/hot-water-recirculation.md
@@ -67,7 +67,7 @@ flowchart LR
 
 For this to react quickly, the probe needs to report faster than its 60 second default. Donovan reports it every 3 seconds and keeps a 60 second heartbeat, so Home Assistant reacts fast while you can still tell at a glance that the probe is alive. Two guards keep the data clean: the `85.0` reading a DS18B20 sends at power-on is dropped, and readings are ignored when the **Select Probe** option is set to `Food`.
 
-For the full walkthrough of overriding probe YAML in the ESPHome Builder, including the simpler delta-plus-heartbeat pattern, see [How To Change The Temperature Probe Update Interval](../setup/temp1-change-temp-probe-update-interval.md).
+For the full walkthrough of overriding probe YAML in the ESPHome Builder, including the simpler delta-plus-heartbeat pattern, see [How To Change The Temperature Probe Update Interval](/products/temp1/setup/temp1-change-temp-probe-update-interval.md).
 
 ```yaml
 sensor:

--- a/docs/products/temp1b/examples/hot-water-recirculation.md
+++ b/docs/products/temp1b/examples/hot-water-recirculation.md
@@ -1,0 +1,11 @@
+---
+title: Hot Water Recirculation with TEMP-1
+description: How a community member uses an Apollo TEMP-1 to drive a hot water recirculation loop, blending an instant mini tank with the main house heater and wasting no water down the drain.
+---
+# Hot Water Recirculation with TEMP-1
+
+!!! warning "Running this on a TEMP-1B"
+
+    This loop needs the probe reporting every few seconds, so it has to stay powered. Run your TEMP-1B on USB power with **Prevent Sleep** turned on, or use a mains-powered TEMP-1. On battery with deep sleep, it can't react fast enough to switch the valve in time.
+
+--8<-- "products/temp1/examples/hot-water-recirculation.md:7:"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -398,6 +398,7 @@ nav:
                 - Alert Outside Range: products/temp1b/examples/temp1b-alert-example.md
                 - Use Cases: products/temp1b/examples/use-cases.md
                 - Automations: products/temp1b/examples/temp1b-automation-examples.md
+                - Hot Water Recirculation: products/temp1b/examples/hot-water-recirculation.md
               - Troubleshooting:
                 - TEMP-1B Boot Mode: products/temp1b/troubleshooting/temp1b-boot-mode.md
                 - Factory Re-Flash TEMP-1B: products/temp1b/troubleshooting/temp1b-code.md


### PR DESCRIPTION
Adds the **Hot Water Recirculation** example to **TEMP-1B > Examples**, mirroring the TEMP-1 page via a snippet include so the two stay in sync.

- New `docs/products/temp1b/examples/hot-water-recirculation.md` pulls the TEMP-1 page content with `--8<-- "...:7:"`
- Adds a TEMP-1B-specific note: the loop needs continuous power (run on USB with Prevent Sleep, or use a mains TEMP-1), since a battery TEMP-1B deep-sleeps
- Makes the TEMP-1 page's update-interval link absolute so it resolves inside the snippet include (and added to TEMP-1B nav)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Hot Water Recirculation” example page for the TEMP-1B product.
  * Included a navigation link so the example is easier to find from the product docs.

* **Bug Fixes**
  * Updated a documentation link in the TEMP-1 example to use the correct path, improving navigation to the setup guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->