### PR TITLE
Update ESPHome installer links to esphome.io/install

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/faq.md
+++ b/docs/products/ESPHome-Starter-Kit/faq.md
@@ -32,7 +32,7 @@ description: Frequently asked questions about the ESPHome Starter Kit, ESPHome D
 
 7\. **What is the ESPHome Desktop app?**
 
-* ESPHome Desktop is the free, open source desktop version of the ESPHome Device Builder. It runs on Mac, Windows, and Linux. For the first time, new users no longer need to install Home Assistant first, set up a Raspberry Pi, or run a server to use ESPHome. Download it, plug in the kit, and a guided setup walks you through the rest. Open <a href="https://desktop.esphome.io" target="_blank" rel="noreferrer nofollow noopener">desktop.esphome.io</a> to download the latest release for your operating system, then follow [First Steps](setup/first-steps.md) to set up your first device. For a deeper look at how ESPHome and the app fit together, see [Explaining ESPHome](learning-the-basics/explaining-esphome.md).
+* ESPHome Desktop is the free, open source desktop version of the ESPHome Device Builder. It runs on Mac, Windows, and Linux. For the first time, new users no longer need to install Home Assistant first, set up a Raspberry Pi, or run a server to use ESPHome. Download it, plug in the kit, and a guided setup walks you through the rest. Open <a href="https://esphome.io/install" target="_blank" rel="noreferrer nofollow noopener">esphome.io/install</a> to download the latest release for your operating system, then follow [First Steps](setup/first-steps.md) to set up your first device. For a deeper look at how ESPHome and the app fit together, see [Explaining ESPHome](learning-the-basics/explaining-esphome.md).
 
 8\. **What can I build with it?**
 

--- a/docs/products/ESPHome-Starter-Kit/setup/first-steps.md
+++ b/docs/products/ESPHome-Starter-Kit/setup/first-steps.md
@@ -34,7 +34,7 @@ Pick the platform you'll be running ESPHome Device Builder on:
 
 === "Windows"
 
-    1. Open <a href="https://desktop.esphome.io" target="_blank" rel="noreferrer nofollow noopener">desktop.esphome.io</a> and click **Download installer** under the **Windows** tab.
+    1. Open <a href="https://esphome.io/install" target="_blank" rel="noreferrer nofollow noopener">esphome.io/install</a> and click **Download installer** under the **Windows** tab.
     2. Open the installer and click **Next** then click **Next** again to start the installation process. Once it shows completed, click **Next** again then **Finish** to complete the installation.
 
     !!! warning "You may see Windows prompts during install"
@@ -55,7 +55,7 @@ Pick the platform you'll be running ESPHome Device Builder on:
 
 === "Mac"
 
-    1. Open <a href="https://desktop.esphome.io" target="_blank" rel="noreferrer nofollow noopener">desktop.esphome.io</a>. The page detects your OS and shows the macOS downloads. Pick the build that matches your chip:
+    1. Open <a href="https://esphome.io/install" target="_blank" rel="noreferrer nofollow noopener">esphome.io/install</a>. The page detects your OS and shows the macOS downloads. Pick the build that matches your chip:
 
         - **Apple Silicon** (M1, M2, M3, M4, M5)
         - **Intel Mac**
@@ -94,7 +94,7 @@ Pick the platform you'll be running ESPHome Device Builder on:
 
 === "Linux"
 
-    1.  Open <a href="https://desktop.esphome.io" target="_blank" rel="noreferrer nofollow noopener">desktop.esphome.io</a>. The page opens on the **Linux** tab and shows **Download .deb** as the default. Click **Download .deb** to grab the Debian / Ubuntu package.
+    1.  Open <a href="https://esphome.io/install" target="_blank" rel="noreferrer nofollow noopener">esphome.io/install</a>. The page opens on the **Linux** tab and shows **Download .deb** as the default. Click **Download .deb** to grab the Debian / Ubuntu package.
 
         If your distro fits a different format, switch to the matching tab on the download page first:
 


### PR DESCRIPTION
## What

esphome.io [PR #6669](https://github.com/esphome/esphome-docs/pull/6669) moves the ESPHome Device Builder download page from `desktop.esphome.io` to `esphome.io/install` ([deploy preview](https://deploy-preview-6669--esphome.netlify.app/install/)). This updates our Starter Kit links to the new URL.

## Changes

- `products/ESPHome-Starter-Kit/setup/first-steps.md` — Windows / Mac / Linux install tabs (3 links)
- `products/ESPHome-Starter-Kit/faq.md` — "What is the ESPHome Desktop app?" answer (1 link)

## Note

The new `esphome.io/install` URL isn't live until upstream #6669 merges, so these links will 404 briefly until then. That's acceptable — the ESPHome Starter Kit is still unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)