### PR TITLE
Sync dev → main: bump CI actions (checkout v7, cache v6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           key: ${{ github.ref }}
           path: .cache


### PR DESCRIPTION
Sync the Dependabot GitHub Actions bump (#994) to main: actions/checkout v6→v7, actions/cache v5→v6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)