### PR TITLE
Clean up docs landing page header

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ description: >-
   Guide to integrating Apollo Automation devices with the Home Assistant smart
   home platform.
 ---
-<img height="344" width="900" src="https://imagedelivery.net/VXI8oYYsJOyBOIySOviPCQ/4e7161b4-573c-40fa-0465-648a99bafe00/public" />
+<h1 style="display: none">Apollo Automation Docs</h1>
 
 !!! info "Welcome to Apollo Automation Docs!"
 


### PR DESCRIPTION
Remove the banner logo image from the top of the landing page and suppress the auto-injected **Home** H1 so the page opens directly on the welcome admonition. A hidden H1 preserves the document outline for SEO/accessibility (mkdocs-material only injects the nav-title H1 when the page body has no heading of its own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)