### PR TITLE
State blue-side-up cable orientation in every FPC attach step

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/modules/apollo-breakout-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/apollo-breakout-module.md
@@ -27,7 +27,7 @@ Connect the Breakout Module to the ESP32-C6 using one of the FPC ribbon cables t
 
     The latches are small and the ribbon cable is fragile. Lift the latch with a fingernail, slide the cable in, and press the latch down. Never pull on the cable itself.
 
-2\. Flip up the latch on the FPC connector then gently slide the ribbon cable in to the connector. Gently press the latch down to lock it in place.
+2\. Flip up the latch on the FPC connector then gently slide the ribbon cable in to the connector with the blue side facing upwards. Gently press the latch down to lock it in place.
 
 ![](../../../assets/esphome-starter-kit-attach-top-fpc-ribbon.webp)
 

--- a/docs/products/ESPHome-Starter-Kit/modules/button-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/button-module.md
@@ -27,7 +27,7 @@ Connect the button module to the ESP32-C6 using one of the FPC ribbon cables tha
 
     The latches are small and the ribbon cable is fragile. Lift the latch with a fingernail, slide the cable in, and press the latch down. Never pull on the cable itself.
 
-2\. Flip up the latch on the FPC connector then gently slide the ribbon cable in to the connector. Gently press the latch down to lock it in place.
+2\. Flip up the latch on the FPC connector then gently slide the ribbon cable in to the connector with the blue side facing upwards. Gently press the latch down to lock it in place.
 
 ![](../../../assets/esphome-starter-kit-attach-top-fpc-ribbon.webp)
 

--- a/docs/products/ESPHome-Starter-Kit/modules/motion-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/motion-module.md
@@ -37,11 +37,11 @@ Connect the motion module to the ESP32-C6 using one of the FPC ribbon cables tha
 
     The latches are small and the ribbon cable is fragile. Lift the latch with a fingernail, slide the cable in, and press the latch down. Never pull on the cable itself.
 
-2\. Flip up the latch on the FPC connector then gently slide the ribbon cable in to the connector. Gently press the latch down to lock it in place
+2\. Flip up the latch on the FPC connector then gently slide the ribbon cable in to the connector with the blue side facing upwards. Gently press the latch down to lock it in place.
 
 ![](../../../assets/esphome-starter-kit-attach-top-fpc-ribbon.webp)
 
-3\. Slide the ribbon cable into the button module with the blue side facing upwards then press the latch down to lock it in place.
+3\. Slide the ribbon cable into the motion module with the blue side facing upwards then press the latch down to lock it in place.
 
 ![](../../../assets/esphome-starter-kit-attach-fpc-to-motion-module.webp)
 

--- a/docs/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module.md
@@ -27,11 +27,11 @@ Connect the LED & Buzzer module to the ESP32-C6 using one of the FPC ribbon cabl
 
     The latches are small and the ribbon cable is fragile. Lift the latch with a fingernail, slide the cable in, and press the latch down. Never pull on the cable itself.
 
-2\. Flip up the latch on the FPC connector then gently slide the ribbon cable in to the connector. Gently press the latch down to lock it in place
+2\. Flip up the latch on the FPC connector then gently slide the ribbon cable in to the connector with the blue side facing upwards. Gently press the latch down to lock it in place.
 
 ![](../../../assets/esphome-starter-kit-attach-top-fpc-ribbon.webp)
 
-3\. Slide the ribbon cable into the button module with the blue side facing upwards then press the latch down to lock it in place.
+3\. Slide the ribbon cable into the LED & buzzer module with the blue side facing upwards then press the latch down to lock it in place.
 
 ![](../../../assets/esphome-starter-kit-attach-fpc-to-rgb-buzzer-module.webp)
 

--- a/docs/products/ESPHome-Starter-Kit/modules/temperature-humidity-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/temperature-humidity-module.md
@@ -28,7 +28,7 @@ Connect the Temperature and Humidity module to the ESP32-C6 using one of the FPC
 
     The latches are small and the ribbon cable is fragile. Lift the latch with a fingernail, slide the cable in, and press the latch down. Never pull on the cable itself.
 
-2\. Flip up the latch on the FPC connector then gently slide the ribbon cable in to the connector. Gently press the latch down to lock it in place.
+2\. Flip up the latch on the FPC connector then gently slide the ribbon cable in to the connector with the blue side facing upwards. Gently press the latch down to lock it in place.
 
 ![](../../../assets/esphome-starter-kit-attach-top-fpc-ribbon.webp)
 


### PR DESCRIPTION
## What

A customer reported that the button module page never clearly says the ribbon cable's blue side faces upwards when inserting it into the ESP32-C6 (step 2). Step 3 (the module side) already said it, but step 2 didn't, on any module page.

- Add "with the blue side facing upwards" to step 2 on all five Starter Kit module pages that use an FPC cable (button, motion, LED & Buzzer, temperature & humidity, breakout).
- Fix step 3 on the motion and LED & Buzzer pages, which said "button module" from a copy-paste.
- Add two missing periods on step 2 (motion, LED & Buzzer).

The battery page has no ribbon cable and is untouched. The FAQ already covers cable orientation.

## Verified

`mkdocs build` shows no new warnings on the touched pages; previewed locally with `mkdocs serve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified setup instructions across several ESPHome Starter Kit module guides.
  * Added explicit ribbon cable orientation guidance (“blue side facing up”) and latch-locking steps for easier, more reliable assembly.
  * Corrected a few module names in the step-by-step instructions to match the right hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->