### PR TITLE
Redesign resellers page and remove Open Circuit

### DIFF
--- a/docs/products/general/resellers.md
+++ b/docs/products/general/resellers.md
@@ -2,29 +2,86 @@
 title: List of Resellers
 description: A list of resellers across the globe for Apollo Automation products!
 ---
-![](/assets/apollo-logo.png)
-
 # Resellers
 
-!!! tip "Note for Australia and Canada"
+!!! tip "Note for Australia, Canada, and the EU"
 
-    For all Australian and Canadian orders, [our Shopify site](https://apolloautomation.com/) fulfills from separate Australian and Canadian warehouses and ship directly from those countries not the USA.
-
-Note: All resellers listed in Alphabetical order.
+    [Our Shopify site](https://apolloautomation.com/) ships from regional warehouses, not the USA: Australian and Canadian orders ship from within those countries, and EU orders ship from our warehouse in the Netherlands.
 
 ## USA
 
-* <a href="https://ameridroid.com/search?q=apollo+automation" target="_blank" rel="noreferrer nofollow noopener">Ameridroid</a> (California)
-* <a href="https://www.donglejungle.com/search?q=apollo+automation" target="_blank" rel="noreferrer nofollow noopener">Dongle Jungle</a> (California)
-* <a href="https://www.drzzs.com/product-tag/apollo/" target="_blank" rel="noreferrer nofollow noopener">DrZzs store</a> (Utah)
+<div class="grid cards" markdown>
+
+-   :flag_us: **Ameridroid**
+
+    ---
+
+    California, USA
+
+    [:octicons-arrow-right-24: Visit store](https://ameridroid.com/search?q=apollo+automation){ target=_blank rel="noreferrer nofollow noopener" }
+
+-   :flag_us: **Dongle Jungle**
+
+    ---
+
+    California, USA
+
+    [:octicons-arrow-right-24: Visit store](https://www.donglejungle.com/search?q=apollo+automation){ target=_blank rel="noreferrer nofollow noopener" }
+
+-   :flag_us: **DrZzs store**
+
+    ---
+
+    Utah, USA
+
+    [:octicons-arrow-right-24: Visit store](https://www.drzzs.com/product-tag/apollo/){ target=_blank rel="noreferrer nofollow noopener" }
+
+</div>
 
 ## UK
 
-* <a href="https://thepihut.com/collections/apollo-automation" target="_blank" rel="noreferrer nofollow noopener">The Pi Hut</a>
+<div class="grid cards" markdown>
+
+-   :flag_gb: **The Pi Hut**
+
+    ---
+
+    United Kingdom
+
+    [:octicons-arrow-right-24: Visit store](https://thepihut.com/collections/apollo-automation){ target=_blank rel="noreferrer nofollow noopener" }
+
+</div>
 
 ## Europe
 
-* <a href="https://www.domadoo.fr/en/434_apollo" target="_blank" rel="noreferrer nofollow noopener">Domadoo</a> (France)
-* <a href="https://www.domo-supply.com/en/brand/163-apollo-automation" target="_blank" rel="noreferrer nofollow noopener">Domo-Supply</a> (Switzerland)
-* <a href="https://opencircuit.shop/brand/apollo-automation" target="_blank" rel="noreferrer nofollow noopener">Open Circuit</a> (Netherlands)
-* <a href="https://slimhuisje.nl/collections/vendors?q=Apollo%20Automation" target="_blank" rel="noreferrer nofollow noopener">Slim Huisje</a> (Netherlands)
+<div class="grid cards" markdown>
+
+-   :flag_fr: **Domadoo**
+
+    ---
+
+    France
+
+    [:octicons-arrow-right-24: Visit store](https://www.domadoo.fr/en/434_apollo){ target=_blank rel="noreferrer nofollow noopener" }
+
+-   :flag_ch: **Domo-Supply**
+
+    ---
+
+    Switzerland
+
+    [:octicons-arrow-right-24: Visit store](https://www.domo-supply.com/en/brand/163-apollo-automation){ target=_blank rel="noreferrer nofollow noopener" }
+
+-   :flag_nl: **Slim Huisje**
+
+    ---
+
+    Netherlands
+
+    [:octicons-arrow-right-24: Visit store](https://slimhuisje.nl/collections/vendors?q=Apollo%20Automation){ target=_blank rel="noreferrer nofollow noopener" }
+
+</div>
+
+## Want to carry Apollo products?
+
+If you run a shop and want to stock Apollo devices, email [sales@apolloautomation.com](mailto:sales@apolloautomation.com) and we will get you set up.


### PR DESCRIPTION
## What changed

- Removed Open Circuit from the resellers list (they no longer carry Apollo products)
- Converted the reseller lists to grid cards with country flags, matching the card style used on the mmWave comparison page
- Updated the warehouse note to cover the new EU (Netherlands) warehouse alongside Australia and Canada
- Added a become-a-reseller CTA pointing at sales@apolloautomation.com
- Dropped the top logo image and the alphabetical-order note

## Verification

- `mkdocs build` passes with no new warnings
- Cards, flag emoji, and link attributes verified in the local `mkdocs serve` preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Redesigned the resellers page with regional cards, flag icons, and “Visit store” buttons.
  * Updated regional guidance to include Australia, Canada, and the EU.
  * Added a section for businesses interested in carrying Apollo products, including contact information.
  * Updated the Netherlands reseller listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->