### PR TITLE
Add CAST-1 WizMote Control blueprint page

### DIFF
--- a/docs/products/cast1/examples/wizmote-blueprint.md
+++ b/docs/products/cast1/examples/wizmote-blueprint.md
@@ -1,0 +1,50 @@
+---
+title: CAST-1 WizMote Control
+description: Control your CAST-1 with a WizMote using the Apollo CAST-1 WizMote blueprint in Home Assistant.
+---
+# WizMote Control
+
+A WizMote gives you physical control over playback on your CAST-1. The **Apollo CAST-1 WizMote** blueprint maps each of the nine buttons to a playback action, a light toggle, or any Home Assistant action you want, all set up without leaving Home Assistant.
+
+Every button ships with a sensible default, so your WizMote works the moment you import the blueprint. Open any button's dropdown to change it, or set one to **Send HA Event** to run a custom action like playing a Music Assistant playlist.
+
+| Button | Default action |
+|--------|----------------|
+| On | Play |
+| Off | Pause |
+| Night | Toggle Light |
+| Brightness Up | Volume Up |
+| Brightness Down | Volume Down |
+| Button 1 | Previous Track |
+| Button 2 | Next Track |
+| Button 3 | Send HA Event |
+| Button 4 | Send HA Event |
+
+Each dropdown offers the same choices: Nothing, Play, Pause, Play / Pause, Next Track, Previous Track, Volume Up, Volume Down, Toggle Light, or Send HA Event.
+
+### Pair Your WizMote
+
+Before the blueprint can control anything, pair your WizMote with the CAST-1.
+
+1\. On your CAST-1 device page, turn on **WizMote Auto-Discovery**.
+
+2\. Press any button on your WizMote. The CAST-1 pairs with it and **WizMote Status** updates to show the paired remote. (1)
+{ .annotate }
+
+1.  Pairing a different WizMote later? Use **Clear WizMote Pairing** on the device to unpair, then turn **WizMote Auto-Discovery** back on and press a button on the new remote.
+
+### Import the Blueprint
+
+1\. Click the Import Blueprint button below then click **Open link**.
+
+<a href="https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2FApolloAutomation%2FBlueprints%2Fblob%2Fmain%2FCAST-1%2FCAST-1-WizMote.yaml" target="_blank" rel="noreferrer noopener"><img alt="Import Blueprint" src="https://my.home-assistant.io/badges/blueprint_import.svg" /></a>
+
+2\. Click **Preview** then click **Import Blueprint**.
+
+3\. Click on **Apollo CAST-1 WizMote**, then click **Select a device** and choose your **Apollo CAST-1** from the dropdown.
+
+4\. Every button already has a default, so your WizMote works right away. To change one, open its dropdown and pick a different action.
+
+5\. For any button set to **Send HA Event** (Buttons 3 and 4 by default), click **Add Action** below it and choose what it should do, like playing a Music Assistant playlist or toggling a light.
+
+6\. Name your automation something like **Apollo CAST-1 WizMote** and click **Save**. Your WizMote now controls your CAST-1!

--- a/docs/products/cast1/introduction.md
+++ b/docs/products/cast1/introduction.md
@@ -8,6 +8,6 @@ description: Documentation for CAST-1, including setup, usage, and best practice
 
 **Multi-Room Audio:** Group several CAST-1s to play the same music in sync across every room. Streaming runs locally through Music Assistant and Sendspin, so there's no cloud account and no subscription.
 
-**WizMote Control:** Pair a Wiz WizMote for physical control over playback without opening an app. Each of the nine buttons is configurable in Home Assistant using the CAST-1 WizMote blueprint, so a button can play, pause, skip, change the volume, or run any Home Assistant action you want.
+**WizMote Control:** [Pair a WizMote](examples/wizmote-blueprint.md) for physical control over playback without opening an app. Each of the nine buttons is configurable in Home Assistant using the CAST-1 WizMote blueprint, so a button can play, pause, skip, change the volume, or run any Home Assistant action you want.
 
 **Line-Level Output:** The CAST-1 outputs line level over 3.5mm and has no amplifier of its own, so it feeds powered speakers, a receiver, or an active soundbar.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -534,6 +534,8 @@ nav:
           - Additional Info:
             - Sensor Definitions: products/cast1/setup/sensor-definitions.md
             - ESPHome Device Builder: products/cast1/additional-info/esphome-device-builder.md
+          - Examples:
+            - WizMote Control: products/cast1/examples/wizmote-blueprint.md
           - Troubleshooting:
             - CAST-1 Boot Mode: products/cast1/troubleshooting/cast1-boot-mode.md
             - Factory Re-Flash CAST-1: products/cast1/troubleshooting/cast1-reflash.md


### PR DESCRIPTION
Add the CAST-1 WizMote Control page (Examples: import the Apollo CAST-1 WizMote blueprint, pair a WizMote, map the 9 buttons) and re-link it from the Introduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
