### PR TITLE
Fix rows x cols order for M-1 multiple panel setups

### DIFF
--- a/docs/products/m1/setup/m1-matrix-settings.md
+++ b/docs/products/m1/setup/m1-matrix-settings.md
@@ -63,7 +63,7 @@ To change it, click on **Config**, then **WiFi Setup**. In the **mDNS address** 
     | rows x cols | 1 and 1 |
     | Reversed | unchecked |
 
-    Both boxes are 1 on a single panel. The first is how many panels across and the second is how many down, which only matters once you [add panels](/products/m1/setup/m1-multiple-panels.md).
+    Both boxes are 1 on a single panel. The first is how many panels down and the second is how many across, which only matters once you [add panels](/products/m1/setup/m1-multiple-panels.md).
 
     **Enable automatic brightness limiter** stays unchecked and **Global brightness factor** stays at 100%. **Total LEDs** at the top of the page should read **4096**. Click **Save**.
 

--- a/docs/products/m1/setup/m1-multiple-panels.md
+++ b/docs/products/m1/setup/m1-multiple-panels.md
@@ -86,15 +86,13 @@ Wiring is the same whichever firmware you run. Choose the number of panels you a
 
     ![](/assets/wled-2x2-matrix-led-setup.png)
 
-    !!! warning "Enter width first"
-
-        The first box is how many panels **across**, the second is how many **down**. Four panels in a row is **4** then **1**. A 2x2 square is **2** then **2**. The label reads rows x cols, but width goes first on both WLED and WLED-MM.
+    **rows x cols** means what it says. The first box is how many panels **down**, the second is how many **across**, so a row of four panels is **1** then **4**.
 
     | Layout | No. of Panels | rows x cols | Total LEDs |
     | --- | --- | --- | --- |
-    | Two panels | 2 | 2 and 1 | 8192 |
-    | Three panels | 3 | 3 and 1 | 12288 |
-    | Four panels in a row | 4 | 4 and 1 | 16384 |
+    | Two panels | 2 | 1 and 2 | 8192 |
+    | Three panels | 3 | 1 and 3 | 12288 |
+    | Four panels in a row | 4 | 1 and 4 | 16384 |
     | 2x2 grid | 4 | 2 and 2 | 16384 |
 
     On a 2x2, do not add a software flip for the upside-down bottom row. The 2 x 2 mapping already assumes the serpentine-with-rotated-bottom-row build described above.
@@ -106,7 +104,7 @@ Wiring is the same whichever firmware you run. Choose the number of panels you a
 
     ![](/assets/wled-2x2-matrix-2d-setup.png)
 
-    Set **Dimensions (WxH)** to the combined size of your layout. (1)
+    Set **Dimensions (WxH)** to the combined size of your layout. This field is width first, unlike **rows x cols** above. (1)
     { .annotate }
 
     1.  2D Configuration does not follow the HUB75 change automatically, so this is the step people miss.


### PR DESCRIPTION
The **rows x cols** field on the WLED LED Preferences page takes rows first, so a horizontal row of four panels is **1** and **4**. The wiki had it backwards and carried a warning box telling readers to enter width first.

This matches the [upstream WLED HUB75 docs](https://kno.wled.ge/advanced/HUB75/), which describe a single horizontal row of four 64x64 panels as a `1 x 4` layout and a square as `2 x 2`.

**Multiple Panels**

- Dropped the `Enter width first` warning and replaced it with one line above the table.
- Table corrected: two panels is `1 and 2`, three is `1 and 3`, four in a row is `1 and 4`. The 2x2 grid row is symmetric and unchanged.
- Added a note that **Dimensions (WxH)** on the 2D Configuration page uses the opposite order, since the two screens disagree and that is what makes this easy to get wrong. The Dimensions table itself was already correct.

**Matrix Settings**

- Same across/down claim appeared here for the single-panel case. Corrected. The `1 and 1` table entry is symmetric and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
