### PR TITLE
Say software instead of firmware across the Starter Kit wiki

### DIFF
--- a/docs/products/ESPHome-Starter-Kit/automations/button-controlled-leds.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/button-controlled-leds.md
@@ -74,13 +74,17 @@ ESPHome Device Builder has a new GUI for building <a href="https://esphome.io/au
 
     See [Device Builder Tour → YAML editor (right)](/products/ESPHome-Starter-Kit/learning-the-basics/device-builder-tour.md#yaml-editor-right) for the full breakdown of the YAML pane.
 
-## Install the firmware
+## Install the software
 
-Your automation is saved in Device Builder, but the device is still running its old firmware. Compile and install the new code to push the change.
+Your automation is saved in Device Builder, but the device is still running its old software. Compile and install the new code to push the change.
 
-1. Click **Save** in the bottom right of the editor.
-2. Click **Install**, then pick **On the Network** to push the new firmware over Wi-Fi.
-3. Wait for the compile and flash to finish. The device reboots once the install is done.
+1.  Click **Save** in the bottom right of the editor.
+2.  Click **Install**, then pick **On the Network** to push the new software over Wi-Fi. (1)
+    { .annotate }
+
+    1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
+
+3.  Wait for the compile and flash to finish. The device reboots once the install is done.
 
 ![](../../../assets/esphome-device-builder-install-button-component.gif)
 

--- a/docs/products/ESPHome-Starter-Kit/automations/motion-activated-light.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/motion-activated-light.md
@@ -120,13 +120,17 @@ Right now the lights turn on with motion but never turn off. Add a second trigge
     1.  The **On Press** trigger from the first automation.
     2.  `on_release` is the YAML name for the **On Release** trigger, firing when the sensor stops reporting motion.
 
-## Install the firmware
+## Install the software
 
-Your automation is saved in Device Builder, but the device is still running its old firmware. Compile and install the new code to push the change.
+Your automation is saved in Device Builder, but the device is still running its old software. Compile and install the new code to push the change.
 
-1. Click **Save** in the bottom right of the editor.
-2. Click **Install**, then pick **On the Network** to push the new firmware over Wi-Fi.
-3. Wait for the compile and flash to finish. The device reboots once the install is done.
+1.  Click **Save** in the bottom right of the editor.
+2.  Click **Install**, then pick **On the Network** to push the new software over Wi-Fi. (1)
+    { .annotate }
+
+    1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
+
+3.  Wait for the compile and flash to finish. The device reboots once the install is done.
 
 ![](../../../assets/esphome-device-builder-install-firmware-motion-sensor.gif)
 

--- a/docs/products/ESPHome-Starter-Kit/automations/play-a-tune.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/play-a-tune.md
@@ -94,13 +94,17 @@ ESPHome Device Builder has a GUI for building <a href="https://esphome.io/automa
 
     See [Device Builder Tour → YAML editor (right)](../learning-the-basics/device-builder-tour.md#yaml-editor-right) for the full breakdown of the YAML pane.
 
-## Install the firmware
+## Install the software
 
-Your automation is saved in Device Builder, but the device is still running its old firmware. Compile and install the new code to push the change.
+Your automation is saved in Device Builder, but the device is still running its old software. Compile and install the new code to push the change.
 
-1. Click **Save** in the bottom right of the editor.
-2. Click **Install**, then pick **On the Network** to push the new firmware over Wi-Fi.
-3. Wait for the compile and flash to finish. The device reboots once the install is done.
+1.  Click **Save** in the bottom right of the editor.
+2.  Click **Install**, then pick **On the Network** to push the new software over Wi-Fi. (1)
+    { .annotate }
+
+    1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
+
+3.  Wait for the compile and flash to finish. The device reboots once the install is done.
 
 ![](../../../assets/esphome-device-builder-install-button-component.gif)
 

--- a/docs/products/ESPHome-Starter-Kit/automations/press-to-check-climate.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/press-to-check-climate.md
@@ -622,13 +622,17 @@ This tutorial has two versions of the same automation. Both end with the same bu
 
     3.  Save and install. Flip the unit select once each direction to verify the numbers convert as you'd expect.
 
-## Install the firmware
+## Install the software
 
-Your automation is saved in Device Builder, but the device is still running its old firmware. Compile and install the new code to push the change.
+Your automation is saved in Device Builder, but the device is still running its old software. Compile and install the new code to push the change.
 
-1. Click **Save** in the bottom right of the editor.
-2. Click **Install**, then pick **On the Network** to push the new firmware over Wi-Fi.
-3. Wait for the compile and flash to finish. The device reboots once the install is done.
+1.  Click **Save** in the bottom right of the editor.
+2.  Click **Install**, then pick **On the Network** to push the new software over Wi-Fi. (1)
+    { .annotate }
+
+    1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
+
+3.  Wait for the compile and flash to finish. The device reboots once the install is done.
 
 ## Test the automation
 

--- a/docs/products/ESPHome-Starter-Kit/automations/temp-reactive-leds.md
+++ b/docs/products/ESPHome-Starter-Kit/automations/temp-reactive-leds.md
@@ -133,13 +133,17 @@ Add a third automation with **Sensor → On Value Range** and **Above** `24.0` (
 
     See [Device Builder Tour → YAML editor (right)](../learning-the-basics/device-builder-tour.md#yaml-editor-right) for the full breakdown of the YAML pane.
 
-## Install the firmware
+## Install the software
 
-Your three automations are saved in Device Builder, but the device is still running its old firmware. Compile and install the new code to push the change.
+Your three automations are saved in Device Builder, but the device is still running its old software. Compile and install the new code to push the change.
 
-1. Click **Save** in the bottom right of the editor.
-2. Click **Install**, then pick **On the Network** to push the new firmware over Wi-Fi.
-3. Wait for the compile and flash to finish. The device reboots once the install is done.
+1.  Click **Save** in the bottom right of the editor.
+2.  Click **Install**, then pick **On the Network** to push the new software over Wi-Fi. (1)
+    { .annotate }
+
+    1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
+
+3.  Wait for the compile and flash to finish. The device reboots once the install is done.
 
 ![](../../../assets/esphome-device-builder-install-button-component.gif)
 

--- a/docs/products/ESPHome-Starter-Kit/everyday-use/play-a-tune-from-home-assistant.md
+++ b/docs/products/ESPHome-Starter-Kit/everyday-use/play-a-tune-from-home-assistant.md
@@ -303,12 +303,16 @@ Start with a single named song, or set up a bank of swappable song slots. Pick a
 
     1.  Pressing Play on an empty field logs *"Unable to determine name; missing ':'"* — the field needs a tune first.
 
-## Install the firmware
+## Install the software
 
-Your actions are saved in Device Builder, but the device is still running its old firmware. Compile and install the new code to push them.
+Your actions are saved in Device Builder, but the device is still running its old software. Compile and install the new code to push them.
 
 1.  Click **Save** in the bottom right of the editor.
-2.  Click **Install**, then pick **On the Network** to push the new firmware over Wi-Fi.
+2.  Click **Install**, then pick **On the Network** to push the new software over Wi-Fi. (1)
+    { .annotate }
+
+    1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
+
 3.  Wait for the compile and flash to finish. The device reboots once the install is done.
 
 ![](../../../assets/esphome-device-builder-rtttl-save-validate-install.gif)

--- a/docs/products/ESPHome-Starter-Kit/learning-the-basics/core-components.md
+++ b/docs/products/ESPHome-Starter-Kit/learning-the-basics/core-components.md
@@ -24,7 +24,10 @@ Apollo ships it on by default so the kit works without Home Assistant. If you on
 - **Version (v2 vs v3).** The Apollo project pins **Version 3**, the newer single-page interface that loads faster, looks cleaner, and shows controls and sensors in a sensible order. v2 is the older multi-page layout. There's almost no reason to switch back.
 - **Port.** Defaults to **80** so plain `esphome-starter-kit.local` works. Change it only if something else on your network is already serving on port 80 and you want to avoid a clash.
 - **Username and password.** Off by default. Set them under **Show advanced settings → Auth** if you want to gate the page so anyone on your Wi-Fi can't toggle your LED. Pair this with `secrets.yaml` so the credentials don't sit in your shared YAML. See <a href="../what-is-secrets-yaml/">What is secrets.yaml?</a> for the pattern.
-- **OTA over the web page.** The v3 web server can accept firmware uploads straight from the browser. Helpful for quick experiments, but turn it off (or behind auth) if your device sits on an untrusted network.
+- **OTA over the web page.** The v3 web server can accept software uploads straight from the browser. (1) Helpful for quick experiments, but turn it off (or behind auth) if your device sits on an untrusted network.
+    { .annotate }
+
+    1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
 - **Including/excluding entities.** Advanced setting that lets you hide specific entities from the web page without removing them from Home Assistant. Useful if you have internal helpers you don't want users to see.
 
 #### Add Component

--- a/docs/products/ESPHome-Starter-Kit/learning-the-basics/device-builder-tour.md
+++ b/docs/products/ESPHome-Starter-Kit/learning-the-basics/device-builder-tour.md
@@ -6,7 +6,10 @@ description: >-
 ---
 # Device Builder Tour
 
-The **ESPHome Device Builder** is the app you used in [First Steps](../setup/first-steps.md) to install firmware on your Starter Kit, and it's where you go every time you change something on the device. This page walks through each screen so you know what you're looking at.
+The **ESPHome Device Builder** is the app you used in [First Steps](../setup/first-steps.md) to install software on your Starter Kit, (1) and it's where you go every time you change something on the device. This page walks through each screen so you know what you're looking at.
+{ .annotate }
+
+1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
 
 ---
 

--- a/docs/products/ESPHome-Starter-Kit/learning-the-basics/explaining-esphome.md
+++ b/docs/products/ESPHome-Starter-Kit/learning-the-basics/explaining-esphome.md
@@ -4,7 +4,10 @@ description: A short overview of what ESPHome is, how the Device Builder app fit
 ---
 # Explaining ESPHome
 
-ESPHome is the open-source firmware project that powers your Apollo ESPHome Starter Kit. You describe what is connected to your ESP32-C6 (a button, a sensor, an LED) and ESPHome runs on the device, exposes those parts to Home Assistant, and accepts updates over the network.
+ESPHome is the open-source software project that powers your Apollo ESPHome Starter Kit. (1) You describe what is connected to your ESP32-C6 (a button, a sensor, an LED) and ESPHome runs on the device, exposes those parts to Home Assistant, and accepts updates over the network.
+{ .annotate }
+
+1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
 
 You do not need to write any code to use it. For the Starter Kit, the **ESPHome Device Builder** app handles it.
 
@@ -13,7 +16,7 @@ You do not need to write any code to use it. For the Starter Kit, the **ESPHome 
 These two names get used interchangeably, but they are different pieces:
 
 - **ESPHome** is the software that runs on your device after it has been flashed. It is what makes your ESP32-C6 talk to Home Assistant, expose its sensors and controls, and accept wireless updates.
-- **ESPHome Device Builder** is the app where you set everything up. Pick the components you want (button, LED, sensor, etc.), click **Install**, and the Builder compiles the firmware and flashes it to your device. Run it as a desktop app on Windows, Mac, or Linux, or install it as a Home Assistant app.
+- **ESPHome Device Builder** is the app where you set everything up. Pick the components you want (button, LED, sensor, etc.), click **Install**, and the Builder compiles the software and flashes it to your device. Run it as a desktop app on Windows, Mac, or Linux, or install it as a Home Assistant app.
 
 For the Starter Kit, you will spend almost all your time in the Device Builder.
 
@@ -34,7 +37,7 @@ For more on how this works under the hood, see [the Home Assistant integration](
 A typical flow looks like this:
 
 1. Click **Add component** in **ESPHome Device Builder** and pick what is connected to your device. No code or YAML required.
-2. Click **Install** to flash the firmware to the device.
+2. Click **Install** to flash the software to the device.
 3. Home Assistant picks up the device through the **ESPHome integration** and shows its sensors, buttons, and lights as entities you can control or automate.
 
 If you ever want to fine-tune something the GUI does not expose, the YAML view is always available. Most users never need it.

--- a/docs/products/ESPHome-Starter-Kit/learning-the-basics/how-esphome-talks-to-home-assistant.md
+++ b/docs/products/ESPHome-Starter-Kit/learning-the-basics/how-esphome-talks-to-home-assistant.md
@@ -22,7 +22,10 @@ The link between your Starter Kit and Home Assistant is encrypted. Both ends use
 
 When Home Assistant configures the device for the first time, it prompts you for that key. If Home Assistant and ESPHome Device Builder run on the same machine, the key is often pre-filled. Otherwise, copy it from `secrets.yaml` in Device Builder and paste it into the Home Assistant prompt.
 
-If the keys do not match, Home Assistant cannot read from or write to the device. The fix is to copy the current `api_encryption_key` value from Device Builder, install firmware to the device, and re-enter the key in Home Assistant.
+If the keys do not match, Home Assistant cannot read from or write to the device. The fix is to copy the current `api_encryption_key` value from Device Builder, install the software to the device, (1) and re-enter the key in Home Assistant.
+{ .annotate }
+
+1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
 
 For more on `secrets.yaml`, see [What is secrets.yaml?](what-is-secrets-yaml.md).
 

--- a/docs/products/ESPHome-Starter-Kit/learning-the-basics/what-is-secrets-yaml.md
+++ b/docs/products/ESPHome-Starter-Kit/learning-the-basics/what-is-secrets-yaml.md
@@ -25,7 +25,10 @@ There are two reasons to use secrets.yaml:
 
 ## How it fits in
 
-secrets.yaml lives inside **ESPHome Device Builder**, not on the device itself. The same secrets file is available to every device you build there. A device only ever sees the substituted values baked into its firmware, not the secrets.yaml file.
+secrets.yaml lives inside **ESPHome Device Builder**, not on the device itself. The same secrets file is available to every device you build there. A device only ever sees the substituted values baked into its software, (1) not the secrets.yaml file.
+{ .annotate }
+
+1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
 
 ## Good practice
 

--- a/docs/products/ESPHome-Starter-Kit/modules/apollo-breakout-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/apollo-breakout-module.md
@@ -141,11 +141,15 @@ The Breakout Module is different from the other starter kit modules. There's no 
 
 The <a href="https://esphome.io/components/" target="_blank" rel="noreferrer nofollow noopener">ESPHome component index</a> lists every supported sensor, switch, light, and more, along with the config each one needs.
 
-## Install the firmware
+## Install the software
 
 Once you've added the component for whatever you wired up, flash the device so your changes go live.
 
-1. Click **Install** on your device card in ESPHome Device Builder.
+1.  Click **Install** on your device card in ESPHome Device Builder. (1)
+    { .annotate }
+
+    1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
+
 2. Choose **Plug into the computer running ESPHome Device Builder** for the first flash, or **On The Network** if the device is already on your Wi-Fi.
 3. Wait for the compile and flash to finish. First builds can take a few minutes.
 4. The device reboots and reconnects to your Wi-Fi on its own.

--- a/docs/products/ESPHome-Starter-Kit/modules/battery.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/battery.md
@@ -50,7 +50,7 @@ A few things to know before you rely on it:
 
 ??? example "How the BTN-1 wakes on button press"
 
-    This is the deep sleep block from the <a href="https://github.com/ApolloAutomation/BTN-1/blob/main/Integrations/ESPHome/Core.yaml" target="_blank" rel="noreferrer nofollow noopener">BTN-1 firmware</a>. The `esp32_ext1_wakeup` section tells the ESP32-C6 to wake when any of the button pins goes high:
+    This is the deep sleep block from the <a href="https://github.com/ApolloAutomation/BTN-1/blob/main/Integrations/ESPHome/Core.yaml" target="_blank" rel="noreferrer nofollow noopener">BTN-1 software</a>. The `esp32_ext1_wakeup` section tells the ESP32-C6 to wake when any of the button pins goes high:
 
     ```yaml
     deep_sleep:
@@ -97,7 +97,10 @@ switch:
 
 The `restore_mode: RESTORE_DEFAULT_ON` line means the device stays awake by default. Get everything working and updated first, then flip the switch off in Home Assistant or the web server when you're ready for the sleep cycle to start. Toggle it while the device is awake, a sleeping device can't hear the command until its next wake-up.
 
-Our battery devices also support a Home Assistant helper that holds every Apollo device awake at once for firmware updates. The same pattern works here, see the [Awake HA Helper guide](/products/general/battery-sensors/awake-ha-helper.md) for the walkthrough.
+Our battery devices also support a Home Assistant helper that holds every Apollo device awake at once for software updates. (1) The same pattern works here, see the [Awake HA Helper guide](/products/general/battery-sensors/awake-ha-helper.md) for the walkthrough.
+{ .annotate }
+
+1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
 
 ## Charging
 

--- a/docs/products/ESPHome-Starter-Kit/modules/button-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/button-module.md
@@ -78,11 +78,15 @@ ESPHome Device Builder ships an **Add Component** flow that knows the pin layout
     | `number: 6` | The GPIO pin (GPIO6) the button module's FPC connector wires to on the ESP32-C6. |
     | `id: button_module` | Internal handle you can reference from automations and lambdas elsewhere in the config. |
 
-## Install the firmware
+## Install the software
 
 Flash the device so the new button entity goes live.
 
-1. Click **Install** on your device card in ESPHome Device Builder.
+1.  Click **Install** on your device card in ESPHome Device Builder. (1)
+    { .annotate }
+
+    1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
+
 2. Choose **Plug into the computer running ESPHome Device Builder** for the first flash, or **On The Network** if the device is already on your Wi-Fi.
 3. Wait for the compile and flash to finish. First builds can take a few minutes.
 4. The device reboots and reconnects to your Wi-Fi on its own.

--- a/docs/products/ESPHome-Starter-Kit/modules/motion-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/motion-module.md
@@ -81,11 +81,15 @@ ESPHome Device Builder ships an **Add Component** flow that knows the pin layout
     | `device_class: motion` | Tells Home Assistant this is a motion sensor, so it shows the right icon and works in motion-related templates and blueprints. |
     | `id: motion_module` | Internal handle you can reference from automations and lambdas elsewhere in the config. |
 
-## Install the firmware
+## Install the software
 
 Flash the device so the new motion entity goes live.
 
-1. Click **Install** on your device card in ESPHome Device Builder.
+1.  Click **Install** on your device card in ESPHome Device Builder. (1)
+    { .annotate }
+
+    1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
+
 2. Choose **Plug into the computer running ESPHome Device Builder** for the first flash, or **On The Network** if the device is already on your Wi-Fi.
 3. Wait for the compile and flash to finish. First builds can take a few minutes.
 4. The device reboots and reconnects to your Wi-Fi on its own.

--- a/docs/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/rgb-buzzer-module.md
@@ -94,11 +94,15 @@ ESPHome Device Builder ships an **Add Component** flow that knows the pin layout
     | `rtttl.output: buzzer_output` | Tells rtttl to use the buzzer output for playback. |
     | `rtttl.id: rtttl_player` | Internal handle for triggering tunes from automations and lambdas. |
 
-## Install the firmware
+## Install the software
 
 Flash the device so the new RGB & Buzzer entities go live.
 
-1. Click **Install** on your device card in ESPHome Device Builder.
+1.  Click **Install** on your device card in ESPHome Device Builder. (1)
+    { .annotate }
+
+    1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
+
 2. Choose **Plug into the computer running ESPHome Device Builder** for the first flash, or **On The Network** if the device is already on your Wi-Fi.
 3. Wait for the compile and flash to finish. First builds can take a few minutes.
 4. The device reboots and reconnects to your Wi-Fi on its own.

--- a/docs/products/ESPHome-Starter-Kit/modules/temperature-humidity-module.md
+++ b/docs/products/ESPHome-Starter-Kit/modules/temperature-humidity-module.md
@@ -86,11 +86,15 @@ ESPHome Device Builder ships an **Add Component** flow that knows the pin layout
     | `temperature` / `humidity` | Two sub-sensors. Each has a `name` shown in Home Assistant and the web server, and an `id` you can reference from automations and lambdas. |
     | `id: aht20` | Internal handle you can reference from automations and lambdas elsewhere in the config. |
 
-## Install the firmware
+## Install the software
 
 Flash the device so the new temperature and humidity entities go live.
 
-1. Click **Install** on your device card in ESPHome Device Builder.
+1.  Click **Install** on your device card in ESPHome Device Builder. (1)
+    { .annotate }
+
+    1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
+
 2. Choose **Plug into the computer running ESPHome Device Builder** for the first flash, or **On The Network** if the device is already on your Wi-Fi.
 3. Wait for the compile and flash to finish. First builds can take a few minutes.
 4. The device reboots and reconnects to your Wi-Fi on its own.

--- a/docs/products/ESPHome-Starter-Kit/setup/first-steps.md
+++ b/docs/products/ESPHome-Starter-Kit/setup/first-steps.md
@@ -26,7 +26,10 @@ By the end you'll have your ESPHome Starter Kit flashed with a working configura
 
 ### ESPHome Device Builder
 
-ESPHome Device Builder is the software that gives you a user interface for writing, compiling, and flashing ESPHome YAML configurations. You'll use it to build the firmware for your kit.
+ESPHome Device Builder is the app that gives you a user interface for writing, compiling, and flashing ESPHome YAML configurations. You'll use it to build the software for your kit. (1)
+{ .annotate }
+
+1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
 
 Think of it like telling the starter kit about what devices it has connected and how to use them!
 
@@ -43,7 +46,7 @@ Pick the platform you'll be running ESPHome Device Builder on:
 
         - If Windows shows a blue **Windows protected your PC** warning, click **More info → Run anyway** to continue.
         - If **Windows Security** asks whether to allow public and private networks to access Python, click **Allow**.
-        - If the installer fails or the Device Builder can't compile firmware, install **Git for Windows** from <a href="https://gitforwindows.org/" target="_blank" rel="noreferrer nofollow noopener">gitforwindows.org</a> and try again. Future installer builds will bundle this for you.
+        - If the installer fails or the Device Builder can't compile the software, install **Git for Windows** from <a href="https://gitforwindows.org/" target="_blank" rel="noreferrer nofollow noopener">gitforwindows.org</a> and try again. Future installer builds will bundle this for you.
 
     ![](../../../assets/esphome-builder-install-windows.gif)
 
@@ -173,7 +176,7 @@ The device is required to be flashed via USB using the bootloader mode the very 
 
 3\. Your device is now in boot mode - The ESP32-C6 will now stay in bootloader mode until you flash it.
 
-### Installing Firmware
+### Installing Software
 
 Before we continue, confirm that you installed the ESPHome Device Builder, configured your components, and put your device in boot mode.
 
@@ -181,7 +184,7 @@ Before we continue, confirm that you installed the ESPHome Device Builder, confi
 2. Click **Install** in the bottom right.
 3. Click **Plug into this computer**.
 4. Select the COM port, then click **Connect** to connect to the ESP32-C6.
-5. Wait for the firmware to compile and install. This usually takes two to five minutes.
+5. Wait for the software to compile and install. This usually takes two to five minutes.
 6. Once it completes, click **Stop**, then press the **Reset** button on your device. Your device will reboot and it's now ready to test out!
 
 ![](../../../assets/device-builder-initial-firmware-install.gif)

--- a/docs/products/ESPHome-Starter-Kit/tutorials/bluetooth-proxy.md
+++ b/docs/products/ESPHome-Starter-Kit/tutorials/bluetooth-proxy.md
@@ -47,13 +47,17 @@ Device Builder has an **Add Component** flow that drops the proxy into your conf
         active: false
     ```
 
-## Install the firmware
+## Install the software
 
-The proxy is saved in Device Builder, but the device is still running its old firmware. Compile and install to push the change.
+The proxy is saved in Device Builder, but the device is still running its old software. Compile and install to push the change.
 
-1. Click **Save** in the bottom right of the editor.
-2. Click **Install**, then pick **On the Network** to push the new firmware over Wi-Fi.
-3. Wait for the compile and flash to finish. The device reboots once the install is done.
+1.  Click **Save** in the bottom right of the editor.
+2.  Click **Install**, then pick **On the Network** to push the new software over Wi-Fi. (1)
+    { .annotate }
+
+    1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
+
+3.  Wait for the compile and flash to finish. The device reboots once the install is done.
 
 ![](../../../assets/esphome-device-builder-add-ble-proxy-save-validate-install.gif)
 

--- a/docs/products/ESPHome-Starter-Kit/tutorials/connect-to-home-assistant.md
+++ b/docs/products/ESPHome-Starter-Kit/tutorials/connect-to-home-assistant.md
@@ -41,7 +41,10 @@ Toggle the **Onboard RGB LED** light entity and confirm the LED responds on the 
 
 #### The encryption key is rejected
 
-Open `secrets.yaml` in Device Builder, copy the `api_encryption_key` value, and paste it back into the Home Assistant prompt. If the value in Device Builder has changed since you last flashed, install the firmware again so the device knows the new key.
+Open `secrets.yaml` in Device Builder, copy the `api_encryption_key` value, and paste it back into the Home Assistant prompt. If the value in Device Builder has changed since you last flashed, install the software again so the device knows the new key. (1)
+{ .annotate }
+
+1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
 
 ---
 

--- a/docs/products/ESPHome-Starter-Kit/tutorials/light-effects.md
+++ b/docs/products/ESPHome-Starter-Kit/tutorials/light-effects.md
@@ -38,12 +38,15 @@ This adds two effects to the light: a continuously cycling rainbow and a sweepin
 
     The starter kit RGB modules are **addressable** lights (each LED can be controlled individually), so look for effect names that start with `addressable_`. Non-addressable effects like `pulse` or `strobe` will not apply.
 
-## Install the firmware
+## Install the software
 
-The effects are saved in Device Builder, but the device is still running its old firmware. Compile and install the new code to push the change.
+The effects are saved in Device Builder, but the device is still running its old software. Compile and install the new code to push the change.
 
-1. Click **Save** in the bottom right of the editor.
-2. Click **Install**, then pick **On the Network** to push the new firmware over Wi-Fi.
+1.  Click **Save** in the bottom right of the editor.
+2.  Click **Install**, then pick **On the Network** to push the new software over Wi-Fi. (1)
+    { .annotate }
+
+    1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
 
 ![](../../../assets/esphome-device-builder-save-install-on-the-network.gif)
 

--- a/docs/products/ESPHome-Starter-Kit/tutorials/using-secrets.md
+++ b/docs/products/ESPHome-Starter-Kit/tutorials/using-secrets.md
@@ -138,7 +138,10 @@ api:
 
 #### OTA password
 
-OTA (over-the-air) updates let you re-flash a device wirelessly after the first USB flash. The password protects that endpoint so a stranger on your network can't push firmware to your device.
+OTA (over-the-air) updates let you re-flash a device wirelessly after the first USB flash. The password protects that endpoint so a stranger on your network can't push software to your device. (1)
+{ .annotate }
+
+1.  We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.
 
 In secrets.yaml:
 


### PR DESCRIPTION
Beginners read "firmware" as something lower-level and scarier than what they are actually doing in Device Builder. Every reader-facing mention of "firmware" in the ESPHome Starter Kit section now says "software", with a per-page annotation noting that the technically correct term is firmware.

The annotation text, used on all 22 pages:

> We say software because it's the friendlier word. The technically correct term is firmware: code that runs directly on the chip instead of on a computer. That's the word ESPHome's own docs use.

## What changed

- 22 pages, including the repeated **Install the firmware** section heading and its steps, and the **Installing Firmware** heading in First Steps (sidebar entry updated with it)
- One annotation per page, placed on the first swapped mention, so no page ends up with two markers in the same section
- First Steps now calls Device Builder "the app" rather than "the software", which avoided saying software twice in two sentences

## What deliberately did not change

- Asset filenames such as `device-builder-initial-firmware-install.gif`. They are paths, not reader-facing text.
- Any other product wiki. The scope is the ESPHome Starter Kit section only.

## Verification

Checked against a local `mkdocs serve` with a headless browser rather than the built HTML, since annotations are attached at runtime. On each variant (numbered step, bullet, plain paragraph): the marker renders, the list keeps its real step count with no phantom items, and no literal `(1)` leaks into the text. No new build warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated ESPHome Starter Kit guides to use “software” as the user-facing term for installed device code.
  - Added notes clarifying that “firmware” is the technically precise term.
  - Renamed installation sections and refreshed related steps, terminology, and annotations throughout setup, tutorials, modules, and automation guides.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->